### PR TITLE
Addressing `0 (NA%)` recoding issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 
 * Added `{flextable}` specs for `theme_gtsummary_roche()`. Mainly border line width (0.5) and footer font size (`font_size` - 1).
 
-* Fix in `tbl_demographics()` when an all NA column within a stratum. The zero count was displayed as `"0 (NA%)"` instead of `"0"`. (#60)
+* Fix in `tbl_demographics()` when a variable is all `NA` within a stratum. The zero count was displayed as `"0 (NA%)"` instead of `"0"`. (#60)
 
 # crane 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 * Added `{flextable}` specs for `theme_gtsummary_roche()`. Mainly border line width (0.5) and footer font size (`font_size` - 1).
 
+* Fix in `tbl_demographics()` when an all NA column within a stratum. The zero count was displayed as `"0 (NA%)"` instead of `"0"`. (#60)
+
 # crane 0.1.0
 
 * Initial release

--- a/R/tbl_demographics.R
+++ b/R/tbl_demographics.R
@@ -84,7 +84,7 @@ tbl_demographics <- function(data,
     gtsummary::modify_header(label = "") |>
     # convert "0 (0.0%)" to "0"
     gtsummary::modify_post_fmt_fun(
-      fmt_fun = ~ ifelse(. == "0 (0.0%)", "0", .),
+      fmt_fun = ~ ifelse(. %in% c("0 (0.0%)", "0 (NA%)"), "0", .),
       columns = all_stat_cols()
     ) |>
     # sort the missing row to just below the header row

--- a/tests/testthat/test-tbl_demographics.R
+++ b/tests/testthat/test-tbl_demographics.R
@@ -80,4 +80,3 @@ test_that("tbl_demographics() recode counts for all NA column", {
     "0"
   )
 })
-

--- a/tests/testthat/test-tbl_demographics.R
+++ b/tests/testthat/test-tbl_demographics.R
@@ -63,3 +63,21 @@ test_that("tbl_demographics() |> add_overall() works", {
     "0"
   )
 })
+
+# addresses issue #60, when all NA column was tabulated it was returned as
+#   "0 (NA%)" instead of "0"
+test_that("tbl_demographics() recode counts for all NA column", {
+  expect_equal(
+    cards::ADSL |>
+      dplyr::mutate(DTHCAT = ifelse(dplyr::row_number() == 1L, "ADVERSE EVENT", NA)) |>
+      tbl_demographics(
+        by = "ARM",
+        include = "DTHCAT"
+      ) |>
+      as.data.frame(col_labels = FALSE) |>
+      dplyr::pull(stat_3) |>
+      dplyr::last(),
+    "0"
+  )
+})
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix in `tbl_demographics()` when an all NA column within a stratum. The zero count was displayed as `"0 (NA%)"` instead of `"0"`. (#60)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #60

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
