### PR TITLE
Bolding headers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # crane 0.1.0.9046
 
+* Making the header bold within `flextable` standard format.
+
 * Updated Roche theme to include parentheses around Ns in header, and updated function defaults to include the parentheses in crane functions.
 
 * Re-coding `0 / 0 (NA%)` to `0 / 0` in `modify_zero_recode()`. (#85)

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -73,8 +73,7 @@ theme_gtsummary_roche <- function(font_size = NULL,
     c(
       lst_theme$`as_flex_table-lst:addl_cmds`,
       list(
-        fontsize =
-          list(
+        fontsize = list(
             rlang::expr(flextable::fontsize(size = !!(font_size %||% 8), part = "all")),
             rlang::expr(flextable::fontsize(size = !!((font_size %||% 8) - 1), part = "footer"))
           ),
@@ -83,6 +82,7 @@ theme_gtsummary_roche <- function(font_size = NULL,
           rlang::expr(flextable::border_outer(part = "header", border = !!border))
         ),
         valign = list( # valign only because it will append to to last commands
+          rlang::expr(flextable::bold(bold = TRUE, part = "header")),
           rlang::expr(flextable::valign(valign = "top", part = "all")),
           rlang::expr(flextable::font(fontname = "Arial", part = "all")),
           rlang::expr(flextable::padding(padding.top = 0, part = "all")),

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -6,7 +6,7 @@
 #' - Uses `label_roche_pvalue()` as the default formatting function for all p-values.
 #' - Uses `label_roche_percent()` as the default formatting function for all percent values.
 #' - Font size defaults are 8 points for all the table by the footers that are 7 points.
-#' - If flextable, header text is always bold.
+#' - If flextable-printed, header text is always bold.
 #' - Border defaults to `flextable::fp_border_default(width = 0.5)`.
 #' - The `add_overall(col_label)` default value has been updated.
 #' - The results from `gtsummary::tbl_hierachrical()` and `gtsummary::tbl_hierachrical_count()`

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -75,9 +75,9 @@ theme_gtsummary_roche <- function(font_size = NULL,
       lst_theme$`as_flex_table-lst:addl_cmds`,
       list(
         fontsize = list(
-            rlang::expr(flextable::fontsize(size = !!(font_size %||% 8), part = "all")),
-            rlang::expr(flextable::fontsize(size = !!((font_size %||% 8) - 1), part = "footer"))
-          ),
+          rlang::expr(flextable::fontsize(size = !!(font_size %||% 8), part = "all")),
+          rlang::expr(flextable::fontsize(size = !!((font_size %||% 8) - 1), part = "footer"))
+        ),
         border = list(
           rlang::expr(flextable::border_outer(part = "body", border = !!border)),
           rlang::expr(flextable::border_outer(part = "header", border = !!border))

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -6,6 +6,7 @@
 #' - Uses `label_roche_pvalue()` as the default formatting function for all p-values.
 #' - Uses `label_roche_percent()` as the default formatting function for all percent values.
 #' - Font size defaults are 8 points for all the table by the footers that are 7 points.
+#' - If flextable, header text is always bold.
 #' - Border defaults to `flextable::fp_border_default(width = 0.5)`.
 #' - The `add_overall(col_label)` default value has been updated.
 #' - The results from `gtsummary::tbl_hierachrical()` and `gtsummary::tbl_hierachrical_count()`

--- a/man/crane-package.Rd
+++ b/man/crane-package.Rd
@@ -6,6 +6,8 @@
 \alias{crane-package}
 \title{crane: Supplements the 'gtsummary' Package for Pharmaceutical Reporting}
 \description{
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
+
 Tables summarizing clinical trial results are often complex and require detailed tailoring prior to submission to a health authority. The 'crane' package supplements the functionality of the 'gtsummary' package for creating these often highly bespoke tables in the pharmaceutical industry.
 }
 \seealso{

--- a/man/tbl_hierarchical_rate_by_grade.Rd
+++ b/man/tbl_hierarchical_rate_by_grade.Rd
@@ -72,18 +72,22 @@ specifies how summary statistics are rounded. Values may be either integer(s) or
 default formatting is assigned via \code{label_style_number()} for statistics \code{n} and \code{N}, and
 \code{label_style_percent(digits=1)} for statistic \code{p}.}
 
-\item{sort}{(\code{string})\cr
-type of sorting to perform. Value must be one of:
+\item{sort}{(\code{\link[gtsummary:syntax]{formula-list-selector}}, \code{string})\cr
+a named list, a list of formulas, a single formula where the list element is a named list of functions
+(or the RHS of a formula), or a string specifying the types of sorting to perform at each hierarchy level.
+If the sort method for any variable is not specified then the method will default to \code{"descending"}. If a single
+unnamed string is supplied it is applied to all hierarchy levels. For each variable, the value specified must
+be one of:
 \itemize{
-\item \code{"alphanumeric"} - at each hierarchy level of the table, rows are ordered alphanumerically (i.e. A to Z)
-by label text.
-\item \code{"descending"} - at each hierarchy level of the table, count sums are calculated for each row and rows are
-sorted in descending order by sum. If \code{sort = "descending"}, the \code{n} statistic is used to calculate row sums if
-included in \code{statistic} for all variables, otherwise \code{p} is used. If neither \code{n} nor \code{p} are present in \code{x} for
-all variables, an error will occur.
+\item \code{"alphanumeric"} - at the specified hierarchy level, groups are ordered alphanumerically (i.e. A to Z) by
+\code{variable_level} text.
+\item \code{"descending"} - at the specified hierarchy level, count sums are calculated for each row and rows are sorted in
+descending order by sum. If \code{sort} is \code{"descending"} for a given variable and \code{n} is included in \code{statistic} for
+the variable then \code{n} is used to calculate row sums, otherwise \code{p} is used. If neither \code{n} nor \code{p} are present
+in \code{x} for the variable, an error will occur.
 }
 
-Defaults to \code{"descending"}.}
+Defaults to \code{everything() ~ "descending"}.}
 
 \item{filter}{(\code{expression})\cr
 An expression that is used to filter rows of the table. Filter will be applied to the second variable (adverse

--- a/man/theme_gtsummary_roche.Rd
+++ b/man/theme_gtsummary_roche.Rd
@@ -32,7 +32,7 @@ A gtsummary theme for Roche tables
 \item Uses \code{label_roche_pvalue()} as the default formatting function for all p-values.
 \item Uses \code{label_roche_percent()} as the default formatting function for all percent values.
 \item Font size defaults are 8 points for all the table by the footers that are 7 points.
-\item If flextable, header text is always bold.
+\item If flextable-printed, header text is always bold.
 \item Border defaults to \code{flextable::fp_border_default(width = 0.5)}.
 \item The \code{add_overall(col_label)} default value has been updated.
 \item The results from \code{gtsummary::tbl_hierachrical()} and \code{gtsummary::tbl_hierachrical_count()}

--- a/man/theme_gtsummary_roche.Rd
+++ b/man/theme_gtsummary_roche.Rd
@@ -32,6 +32,7 @@ A gtsummary theme for Roche tables
 \item Uses \code{label_roche_pvalue()} as the default formatting function for all p-values.
 \item Uses \code{label_roche_percent()} as the default formatting function for all percent values.
 \item Font size defaults are 8 points for all the table by the footers that are 7 points.
+\item If flextable, header text is always bold.
 \item Border defaults to \code{flextable::fp_border_default(width = 0.5)}.
 \item The \code{add_overall(col_label)} default value has been updated.
 \item The results from \code{gtsummary::tbl_hierachrical()} and \code{gtsummary::tbl_hierachrical_count()}

--- a/tests/testthat/_snaps/theme_gtsummary_roche.md
+++ b/tests/testthat/_snaps/theme_gtsummary_roche.md
@@ -30,21 +30,24 @@
       
       $user_added3
       $user_added3[[1]]
-      flextable::valign(valign = "top", part = "all")
+      flextable::bold(bold = TRUE, part = "header")
       
       $user_added3[[2]]
-      flextable::font(fontname = "Arial", part = "all")
+      flextable::valign(valign = "top", part = "all")
       
       $user_added3[[3]]
-      flextable::padding(padding.top = 0, part = "all")
+      flextable::font(fontname = "Arial", part = "all")
       
       $user_added3[[4]]
-      flextable::padding(padding.bottom = 0, part = "all")
+      flextable::padding(padding.top = 0, part = "all")
       
       $user_added3[[5]]
-      flextable::line_spacing(space = 1, part = "all")
+      flextable::padding(padding.bottom = 0, part = "all")
       
       $user_added3[[6]]
+      flextable::line_spacing(space = 1, part = "all")
+      
+      $user_added3[[7]]
       flextable::set_table_properties(layout = "autofit")
       
       


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Making the header bold within `flextable` standard format.

closes #99 


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
