### PR TITLE
Fix remove duplicated lines for unique values

### DIFF
--- a/R/tbl_listing.R
+++ b/R/tbl_listing.R
@@ -149,10 +149,10 @@ remove_duplicate_keys <- function(x, keys = NULL, value = NA) {
   cards::process_selectors(x$table_body, keys = {{ keys }})
   check_scalar(value)
 
-  # Check if keys are unique
-  if (anyDuplicated(x$table_body[keys]) > 0L) {
-    # Create a new data frame with blank values for duplicates
-    for (kcol in keys) {
+  # Create a new data frame with blank values for duplicates
+  for (kcol in keys) {
+    # Check if keys are unique
+    if (anyDuplicated(x$table_body[kcol]) > 0L) {
       tmp_label_attr <- attr(x$table_body[[kcol]], "label") # not losing the label attribute
       kcol_vec <- as.character(x$table_body[[kcol]])
       attr(kcol_vec, "label") <- tmp_label_attr

--- a/tests/testthat/test-tbl_listing.R
+++ b/tests/testthat/test-tbl_listing.R
@@ -9,15 +9,6 @@ test_that("tbl_listing() works with default values", {
   )
 })
 
-test_that("tbl_listing(hide_duplicate_keys = FALSE) works with standard values", {
-  w_duplicated_keys <- tbl_listing(tld) |>
-    remove_duplicate_keys(keys = trt)
-  wo_duplicated_keys <- tbl_listing(tld)
-
-  expect_snapshot(w_duplicated_keys$table_body[seq(3), ])
-  expect_snapshot(wo_duplicated_keys$table_body[seq(3), ])
-})
-
 test_that("tbl_listing(add_blanks_rows) works with standard values", {
   expect_no_error(
     out <- tbl_listing(tld, add_blank_rows = list(variable_level = "age"))
@@ -93,4 +84,21 @@ test_that("tbl_listing(split_by_rows + split_by_columns) works with standard val
   expect_snapshot(
     out[[4]]$table_body
   )
+})
+
+test_that("remove_duplicate_keys() works with standard values", {
+  w_duplicated_keys <- tbl_listing(tld) |>
+    remove_duplicate_keys(keys = trt)
+  wo_duplicated_keys <- tbl_listing(tld)
+
+  expect_snapshot(w_duplicated_keys$table_body[seq(3), ])
+  expect_snapshot(wo_duplicated_keys$table_body[seq(3), ])
+})
+
+test_that("remove_duplicate_keys() works with unique and duplicated values", {
+  # Regression test for #129
+  w_duplicated_keys <- tbl_listing(tld) |>
+    remove_duplicate_keys(keys = c(trt, marker)) # marker is unique, trt is not
+
+  expect_snapshot(w_duplicated_keys$table_body[seq(4), ]) # trt has duplicates, marker does not
 })


### PR DESCRIPTION
* Fixed `remove_duplicate_keys()` to remove non-unique column values when the key columns are a mix of unique and duplicated entries.

#129 

@ayogasekaram ;)
--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
