### PR TITLE
Remove warning on table creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
 
 ### Other Updates
 
+* Remove warning when data has more levels than needed for grade_groups on tbl_hierarchical_rate_by_grade.
+
 * Changed the default `conf.type` from `"log"` to `"plain"` (linear) in `tbl_survfit_times()` and `tbl_survfit_quantiles()` to align with GDSR guidelines. (#173)
 
 * Removed bold from headers when using `tbl_strata()` (#133).
@@ -42,6 +44,7 @@
 * Fixed a bug in `gg_pkc_lineplot()` causing misplaced error bars on a log scale. (#199)
 
 * Adjusted `gg_pkc_lineplot()` to use `tbl_roche_summary()` for automatic decimals formatting.
+
 # crane 0.3.1
 
 ## New Functions and Functionality

--- a/R/tbl_hierarchical_rate_by_grade.R
+++ b/R/tbl_hierarchical_rate_by_grade.R
@@ -228,7 +228,7 @@ tbl_hierarchical_rate_by_grade <- function(data,
     # remove grades not part of any grade groups - these will be duplicated in ard_grouped
     if (!is_empty(grade_groups) && !is_empty(setdiff(lvls, unlist(grade_groups)))) {
       ard_ungrouped <- ard_ungrouped |>
-        dplyr::filter(!unlist(.data[["variable_level"]]) %in% setdiff(lvls, unlist(grade_groups)))
+        dplyr::filter(!.data[["variable_level"]] %in% setdiff(lvls, unlist(grade_groups)))
     }
   }
 

--- a/R/tbl_hierarchical_rate_by_grade.R
+++ b/R/tbl_hierarchical_rate_by_grade.R
@@ -228,7 +228,7 @@ tbl_hierarchical_rate_by_grade <- function(data,
     # remove grades not part of any grade groups - these will be duplicated in ard_grouped
     if (!is_empty(grade_groups) && !is_empty(setdiff(lvls, unlist(grade_groups)))) {
       ard_ungrouped <- ard_ungrouped |>
-        dplyr::filter(!.data[["variable_level"]] %in% setdiff(lvls, unlist(grade_groups)))
+        dplyr::filter(!unlist(.data[["variable_level"]]) %in% setdiff(lvls, unlist(grade_groups)))
     }
   }
 
@@ -453,8 +453,9 @@ tbl_hierarchical_rate_by_grade <- function(data,
   grade <- dplyr::last(variables)
 
   if (!is_empty(grade_groups)) {
+    keep_grade <- vapply(grade_groups, function(x){any(x %in% levels(data[[grade]]))}, TRUE)
     # if any grade groups present, replace grades with their grade groups
-    data[[grade]] <- do.call(fct_collapse, args = c(list(f = data[[grade]]), grade_groups))
+    data[[grade]] <- do.call(fct_collapse, args = c(list(f = data[[grade]]), grade_groups[keep_grade]))
   }
 
   # move grade variable to `by` to get rates by highest grade

--- a/R/tbl_hierarchical_rate_by_grade.R
+++ b/R/tbl_hierarchical_rate_by_grade.R
@@ -453,7 +453,9 @@ tbl_hierarchical_rate_by_grade <- function(data,
   grade <- dplyr::last(variables)
 
   if (!is_empty(grade_groups)) {
-    keep_grade <- vapply(grade_groups, function(x){any(x %in% levels(data[[grade]]))}, TRUE)
+    keep_grade <- vapply(grade_groups, function(x) {
+      any(x %in% levels(data[[grade]]))
+    }, TRUE)
     # if any grade groups present, replace grades with their grade groups
     data[[grade]] <- do.call(fct_collapse, args = c(list(f = data[[grade]]), grade_groups[keep_grade]))
   }

--- a/tests/testthat/test-tbl_hierarchical_rate_by_grade.R
+++ b/tests/testthat/test-tbl_hierarchical_rate_by_grade.R
@@ -263,6 +263,22 @@ test_that("tbl_hierarchical_rate_by_grade(grade_groups) works with some grades n
   )
 })
 
+test_that("tbl_hierarchical_rate_by_grade(grade_groups) works with some grades not in groups and missing grades", {
+  withr::local_options(width = 200)
+
+  expect_silent(
+    tbl <-
+      tbl_hierarchical_rate_by_grade(
+        ADAE_subset[!ADAE_subset$AETOXGR %in% c(3, 4), ],
+        variables = c(AEBODSYS, AEDECOD, AETOXGR),
+        denominator = ADSL,
+        by = TRTA,
+        label = label,
+        grade_groups = list("Grade 3-4" = c("3", "4"))
+      )
+  )
+})
+
 test_that("tbl_hierarchical_rate_by_grade(grades_exclude) works", {
   # no grades excluded
   tbl_no_excl <-

--- a/tests/testthat/test-tbl_hierarchical_rate_by_grade.R
+++ b/tests/testthat/test-tbl_hierarchical_rate_by_grade.R
@@ -266,16 +266,18 @@ test_that("tbl_hierarchical_rate_by_grade(grade_groups) works with some grades n
 test_that("tbl_hierarchical_rate_by_grade(grade_groups) works with some grades not in groups and missing grades", {
   withr::local_options(width = 200)
 
+  # Drop some grades
+  ADAE_subset2 <- ADAE_subset[!ADAE_subset$AETOXGR %in% c(1, 2), ]
+
   expect_silent(
-    tbl <-
-      tbl_hierarchical_rate_by_grade(
-        ADAE_subset[!ADAE_subset$AETOXGR %in% c(3, 4), ],
-        variables = c(AEBODSYS, AEDECOD, AETOXGR),
-        denominator = ADSL,
-        by = TRTA,
-        label = label,
-        grade_groups = list("Grade 3-4" = c("3", "4"))
-      )
+    tbl <- tbl_hierarchical_rate_by_grade(
+      droplevels(ADAE_subset2),
+      variables = c(AEBODSYS, AEDECOD, AETOXGR),
+      denominator = ADSL,
+      by = TRTA,
+      label = label,
+      grade_groups = grade_groups
+    )
   )
 })
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Remove warning when data has more levels than needed for grade_groups.

Provide more detail here as needed.

There is one note on R 4.5.3:

```
checking Rd line widths ... NOTE
  Rd file 'tbl_mmrm.Rd':
    \examples lines wider than 100 characters:
         formula = FEV1 ~ RACE + SEX + ARMCD * AVISIT + us(AVISIT | USUBJID), # us -> unstructured cov structure
  
  These lines will be truncated in the PDF manual.
```
**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
