### PR TITLE
feat: emit zero-rows for unobserved factor levels in tbl_hierarchical_rate_and_count()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,8 @@
  
 ### Other Updates
 
+* `tbl_hierarchical_rate_and_count()` now emits zero-rows for unobserved factor levels in the first hierarchical variable. (#233)
+
 * `df2gg_aligned()` and `df2gg_floating()` now preserve original ggplot objects in `attr(result, "plotlist")` for downstream data extraction after combining with `cowplot`. (#208)
 
 * Remove warning when data has more levels than needed for grade_groups on tbl_hierarchical_rate_by_grade.

--- a/R/tbl_hierarchical_rate_and_count.R
+++ b/R/tbl_hierarchical_rate_and_count.R
@@ -340,13 +340,17 @@ add_overall.tbl_hierarchical_rate_and_count <- function(x,
 
   # only act when the column is a factor with defined levels
 
-  if (!is.factor(col_vals)) return(tbl)
+  if (!is.factor(col_vals)) {
+    return(tbl)
+  }
 
   observed <- unique(as.character(col_vals))
   all_levels <- levels(col_vals)
   missing_levels <- setdiff(all_levels, observed)
 
-  if (length(missing_levels) == 0L) return(tbl)
+  if (length(missing_levels) == 0L) {
+    return(tbl)
+  }
 
   cli::cli_inform(
     c("i" = "Adding zero-rows for {length(missing_levels)} unobserved level{?s} in {.val {top_var}}.")

--- a/R/tbl_hierarchical_rate_and_count.R
+++ b/R/tbl_hierarchical_rate_and_count.R
@@ -12,6 +12,21 @@
 #' `gtsummary::tbl_hierarchical_count()` directly, followed by a call to
 #' `gtsummary::filter_hierarchical()`.
 #'
+#' @details
+#' ## Factor levels and zero-rows
+#'
+#' When the first variable in `variables` is a factor, the function respects
+#' its levels and emits zero-rows for any levels not observed in the data.
+#' Each unobserved level gets a header row (with `NA` stats), a rate summary
+#' row (`"0"`), and a count summary row (`"0"`).
+#'
+#' This is useful when the set of expected categories is predefined but some
+#' may not be present in the data. To exclude categories with no observations,
+#' drop unused levels before calling the function (e.g., `droplevels()`).
+#'
+#' Ensures consistent output structure for empty datasets, removing the
+#' need for manual workarounds in reporting templates.
+#'
 #' @inheritParams gtsummary::tbl_hierarchical
 #' @inheritParams gtsummary::add_overall.tbl_hierarchical
 #' @param variables ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
@@ -51,6 +66,18 @@
 #'     by = TRTA
 #'   ) |>
 #'   add_overall(last = TRUE)
+#'
+#' # Example 2: factor with unobserved levels ----------------------------------
+#' # Adding an unobserved SOC level produces zero-rows automatically
+#' cards::ADAE[c(1, 2, 3, 8, 16), ] |>
+#'   dplyr::mutate(
+#'     AEBODSYS = factor(AEBODSYS, levels = c(unique(AEBODSYS), "UNOBSERVED SOC"))
+#'   ) |>
+#'   tbl_hierarchical_rate_and_count(
+#'     variables = c(AEBODSYS, AEDECOD),
+#'     denominator = cards::ADSL,
+#'     by = TRTA
+#'   )
 NULL
 
 #' @rdname tbl_hierarchical_rate_and_count
@@ -99,6 +126,26 @@ tbl_hierarchical_rate_and_count <- function(data,
 
   # saving function inputs
   tbl_hierarchical_rate_and_count_inputs <- as.list(environment())
+
+  # handle 0-row data with factor levels ---------------------------------------
+  # gtsummary::tbl_hierarchical() cannot process empty data. When the first
+  # variable is a factor we build a scaffold table with zero-rows for all levels.
+  if (nrow(data) == 0L && is.factor(data[[variables[1]]])) {
+    return(
+      .build_empty_scaffold(
+        data = data,
+        variables = variables,
+        by = by,
+        denominator = denominator,
+        label_overall_rate = label_overall_rate,
+        label_overall_count = label_overall_count,
+        label_rate = label_rate,
+        label_count = label_count,
+        label = label,
+        inputs = tbl_hierarchical_rate_and_count_inputs
+      )
+    )
+  }
 
   # process labels -------------------------------------------------------------
   df_variables <- data[variables] |> dplyr::mutate(..ard_hierarchical_overall.. = data[[variables[1]]])
@@ -239,6 +286,18 @@ tbl_hierarchical_rate_and_count <- function(data,
     # convert "0 (0.0%)" to "0"
     modify_zero_recode()
 
+  # append zero-rows for unobserved factor levels ------------------------------
+  # When variables[1] is a factor, emit zero-rows for levels with no events.
+  # gtsummary::tbl_hierarchical() drops unobserved strata levels, so we
+  # re-inject them here to keep the output complete.
+  tbl_final <- .inject_unobserved_levels(
+    tbl_final,
+    data = data,
+    variables = variables,
+    label_rate = label_rate,
+    label_count = label_count
+  )
+
   # return final table ---------------------------------------------------------
   tbl_final$call_list <- list(tbl_hierarchical_rate_and_count = match.call())
   tbl_final$cards <-
@@ -265,4 +324,220 @@ add_overall.tbl_hierarchical_rate_and_count <- function(x,
     what = asNamespace("gtsummary")[["add_overall.tbl_hierarchical"]],
     args = list(x = x, last = last, col_label = col_label)
   )
+}
+
+# Inject zero-rows for unobserved factor levels in the first hierarchical
+# variable. Returns the table unchanged if variables[1] is not a factor or
+# all levels are already present.
+#' @keywords internal
+.inject_unobserved_levels <- function(tbl,
+                                      data,
+                                      variables,
+                                      label_rate,
+                                      label_count) {
+  top_var <- variables[1L]
+  col_vals <- data[[top_var]]
+
+  # only act when the column is a factor with defined levels
+
+  if (!is.factor(col_vals)) return(tbl)
+
+  observed <- unique(as.character(col_vals))
+  all_levels <- levels(col_vals)
+  missing_levels <- setdiff(all_levels, observed)
+
+  if (length(missing_levels) == 0L) return(tbl)
+
+  cli::cli_inform(
+    c("i" = "Adding zero-rows for {length(missing_levels)} unobserved level{?s} in {.val {top_var}}.")
+  )
+
+  stat_cols <- grep("^stat_", names(tbl$table_body), value = TRUE)
+
+  # build zero-rows: header + rate + count per missing level
+  zero_rows <- map(missing_levels, \(lvl) {
+    header <- stats::setNames(
+      rep(NA_character_, length(stat_cols)), stat_cols
+    )
+    summary_row <- stats::setNames(
+      rep("0", length(stat_cols)), stat_cols
+    )
+
+    dplyr::bind_rows(
+      # SOC/basket header row
+      tibble::tibble(
+        row_type = "level",
+        group1 = top_var,
+        group1_level = lvl,
+        var_label = NA_character_,
+        variable = top_var,
+        label = lvl,
+        !!!header
+      ),
+      # rate summary row
+      tibble::tibble(
+        row_type = "level",
+        group1 = top_var,
+        group1_level = lvl,
+        var_label = NA_character_,
+        variable = top_var,
+        label = label_rate,
+        !!!summary_row
+      ),
+      # count summary row
+      tibble::tibble(
+        row_type = "level",
+        group1 = top_var,
+        group1_level = lvl,
+        var_label = NA_character_,
+        variable = top_var,
+        label = label_count,
+        !!!summary_row
+      )
+    )
+  }) |>
+    dplyr::bind_rows()
+
+  # assign ord values that place zero-rows after existing rows
+  max_ord <- max(tbl$table_body$ord, na.rm = TRUE)
+  zero_rows$ord <- seq(max_ord + 1L, length.out = nrow(zero_rows))
+
+  tbl |>
+    gtsummary::modify_table_body(~ dplyr::bind_rows(.x, zero_rows))
+}
+
+# Build a scaffold table when data has 0 rows but variables[1] is a factor.
+# Produces a gtsummary object with correct column headers and zero-rows for
+# every factor level.
+#' @keywords internal
+.build_empty_scaffold <- function(data,
+                                  variables,
+                                  by,
+                                  denominator,
+                                  label_overall_rate,
+                                  label_overall_count,
+                                  label_rate,
+                                  label_count,
+                                  label,
+                                  inputs) {
+  top_var <- variables[1L]
+  all_levels <- levels(data[[top_var]])
+
+  # determine stat columns from denominator
+  if (length(by) > 0L) {
+    stat_cols <- paste0("stat_", seq_along(unique(denominator[[by]])))
+  } else {
+    stat_cols <- "stat_0"
+  }
+
+  zero_val <- stats::setNames(rep("0", length(stat_cols)), stat_cols)
+  na_val <- stats::setNames(rep(NA_character_, length(stat_cols)), stat_cols)
+
+  # overall rate row
+  rows <- list(
+    tibble::tibble(
+      row_type = "level",
+      group1 = "..ard_hierarchical_overall..",
+      group1_level = NA_character_,
+      var_label = NA_character_,
+      variable = "..ard_hierarchical_overall..",
+      label = label_overall_rate,
+      !!!zero_val
+    )
+  )
+
+  # overall count row (unless "remove")
+  if (!identical(label_overall_count, "remove")) {
+    rows <- c(rows, list(
+      tibble::tibble(
+        row_type = "level",
+        group1 = "..ard_hierarchical_overall..",
+        group1_level = NA_character_,
+        var_label = NA_character_,
+        variable = "..ard_hierarchical_overall..",
+        label = label_overall_count,
+        !!!zero_val
+      )
+    ))
+  }
+
+  # per-level rows: header + rate + count
+  for (lvl in all_levels) {
+    rows <- c(rows, list(
+      tibble::tibble(
+        row_type = "level",
+        group1 = top_var,
+        group1_level = lvl,
+        var_label = NA_character_,
+        variable = top_var,
+        label = lvl,
+        !!!na_val
+      ),
+      tibble::tibble(
+        row_type = "level",
+        group1 = top_var,
+        group1_level = lvl,
+        var_label = NA_character_,
+        variable = top_var,
+        label = label_rate,
+        !!!zero_val
+      ),
+      tibble::tibble(
+        row_type = "level",
+        group1 = top_var,
+        group1_level = lvl,
+        var_label = NA_character_,
+        variable = top_var,
+        label = label_count,
+        !!!zero_val
+      )
+    ))
+  }
+
+  body <- dplyr::bind_rows(rows)
+  body$ord <- seq_len(nrow(body))
+
+
+  # build scaffold from tbl_summary to get correct column headers with N counts.
+  # The body is replaced entirely, so the summarized variable is irrelevant.
+  # Use the first column of the denominator as a throwaway include variable.
+  include_var <- names(denominator)[1L]
+  tbl_scaffold <- rlang::inject(
+    gtsummary::tbl_summary(
+      data = denominator,
+      include = dplyr::all_of(include_var),
+      by = !!if (length(by) > 0L) by else NULL
+    )
+  ) |>
+    gtsummary::modify_table_body(\(x) body)
+
+  # process user-supplied labels for the header
+  df_labels <- data[variables]
+  cards::process_formula_selectors(df_labels, label = label)
+  cards::fill_formula_selectors(
+    df_labels,
+    label = lapply(
+      names(df_labels),
+      \(x) attr(df_labels[[x]], "label") %||% x
+    ) |>
+      stats::setNames(names(df_labels))
+  )
+
+  header_label <- paste0(
+    label[[variables[1L]]],
+    "  \n",
+    paste0(rep("\U00A0", 4L), collapse = ""),
+    label[[variables[length(variables)]]]
+  )
+
+  tbl_scaffold <- tbl_scaffold |>
+    gtsummary::modify_header(label ~ header_label)
+
+  tbl_scaffold$call_list <- list(tbl_hierarchical_rate_and_count = match.call())
+  tbl_scaffold$cards <- list(tbl_hierarchical_rate_and_count = list())
+  tbl_scaffold$inputs <- inputs
+
+  tbl_scaffold |>
+    structure(class = c("tbl_hierarchical_rate_and_count", "gtsummary")) |>
+    modify_header_rm_md()
 }

--- a/man/tbl_hierarchical_rate_and_count.Rd
+++ b/man/tbl_hierarchical_rate_and_count.Rd
@@ -104,6 +104,22 @@ When creating a filtered summary, use \code{gtsummary::tbl_hierarchical()} or
 \code{gtsummary::tbl_hierarchical_count()} directly, followed by a call to
 \code{gtsummary::filter_hierarchical()}.
 }
+\details{
+\subsection{Factor levels and zero-rows}{
+
+When the first variable in \code{variables} is a factor, the function respects
+its levels and emits zero-rows for any levels not observed in the data.
+Each unobserved level gets a header row (with \code{NA} stats), a rate summary
+row (\code{"0"}), and a count summary row (\code{"0"}).
+
+This is useful when the set of expected categories is predefined but some
+may not be present in the data. To exclude categories with no observations,
+drop unused levels before calling the function (e.g., \code{droplevels()}).
+
+Ensures consistent output structure for empty datasets, removing the
+need for manual workarounds in reporting templates.
+}
+}
 \examples{
 \dontshow{if (identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) withAutoprint(\{ # examplesIf}
 # Example 1 ----------------------------------
@@ -114,5 +130,17 @@ cards::ADAE[c(1, 2, 3, 8, 16), ] |>
     by = TRTA
   ) |>
   add_overall(last = TRUE)
+
+# Example 2: factor with unobserved levels ----------------------------------
+# Adding an unobserved SOC level produces zero-rows automatically
+cards::ADAE[c(1, 2, 3, 8, 16), ] |>
+  dplyr::mutate(
+    AEBODSYS = factor(AEBODSYS, levels = c(unique(AEBODSYS), "UNOBSERVED SOC"))
+  ) |>
+  tbl_hierarchical_rate_and_count(
+    variables = c(AEBODSYS, AEDECOD),
+    denominator = cards::ADSL,
+    by = TRTA
+  )
 \dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/_snaps/tbl_hierarchical_rate_and_count.md
+++ b/tests/testthat/_snaps/tbl_hierarchical_rate_and_count.md
@@ -2,51 +2,129 @@
 
     Code
       as.data.frame(tbl)
+    Condition
+      Warning in `do.call()`:
+      unable to translate 'Body System or Organ Class  
+      <U+00A0><U+00A0><U+00A0><U+00A0>MedDRA Preferred Term' to native encoding
     Output
-              Body System or Organ Class  \n    MedDRA Preferred Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84) All Participants  \n(N = 254)
-      1  Total number of participants with at least one adverse event            3 (3.5%)                         2 (2.4%)                        1 (1.2%)                      6 (2.4%)
-      2                                Overall total number of events                   5                                4                               1                            10
-      3                                    GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>                          <NA>
-      4  Total number of participants with at least one adverse event            3 (3.5%)                                0                               0                      3 (1.2%)
-      5                                        Total number of events                   3                                0                               0                             3
-      6                                                     DIARRHOEA            3 (3.5%)                                0                               0                      3 (1.2%)
-      7          GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>                          <NA>
-      8  Total number of participants with at least one adverse event            1 (1.2%)                         2 (2.4%)                        1 (1.2%)                      4 (1.6%)
-      9                                        Total number of events                   2                                4                               1                             7
-      10                                    APPLICATION SITE ERYTHEMA            1 (1.2%)                         1 (1.2%)                        1 (1.2%)                      3 (1.2%)
-      11                                    APPLICATION SITE PRURITUS            1 (1.2%)                         2 (2.4%)                               0                      3 (1.2%)
-      12                                                      FATIGUE                   0                         1 (1.2%)                               0                      1 (0.4%)
+         Body System or Organ Class  \n<U+00A0><U+00A0><U+00A0><U+00A0>MedDRA Preferred Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84) All Participants  \n(N = 254)
+      1                         Total number of participants with at least one adverse event     3<U+00A0>(3.5%)                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)               6<U+00A0>(2.4%)
+      2                                                       Overall total number of events                   5                                4                               1                            10
+      3                                                           GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>                          <NA>
+      4                         Total number of participants with at least one adverse event     3<U+00A0>(3.5%)                                0                               0               3<U+00A0>(1.2%)
+      5                                                               Total number of events                   3                                0                               0                             3
+      6                                                                            DIARRHOEA     3<U+00A0>(3.5%)                                0                               0               3<U+00A0>(1.2%)
+      7                                 GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>                          <NA>
+      8                         Total number of participants with at least one adverse event     1<U+00A0>(1.2%)                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)               4<U+00A0>(1.6%)
+      9                                                               Total number of events                   2                                4                               1                             7
+      10                                                           APPLICATION SITE ERYTHEMA     1<U+00A0>(1.2%)                  1<U+00A0>(1.2%)                 1<U+00A0>(1.2%)               3<U+00A0>(1.2%)
+      11                                                           APPLICATION SITE PRURITUS     1<U+00A0>(1.2%)                  2<U+00A0>(2.4%)                               0               3<U+00A0>(1.2%)
+      12                                                                             FATIGUE                   0                  1<U+00A0>(1.2%)                               0               1<U+00A0>(0.4%)
 
 ---
 
     Code
       as.data.frame(tbl)
+    Condition
+      Warning in `do.call()`:
+      unable to translate 'Body System or Organ Class  
+      <U+00A0><U+00A0><U+00A0><U+00A0>High Level Term  
+      <U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term' to native encoding
     Output
-         Body System or Organ Class  \n    High Level Term  \n        Dictionary-Derived Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84) All Participants  \n(N = 254)
-      1                          Total number of participants with at least one adverse event            3 (3.5%)                         2 (2.4%)                        1 (1.2%)                      6 (2.4%)
-      2                                                        Overall total number of events                   5                                4                               1                            10
-      3                                                            GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>                          <NA>
-      4                          Total number of participants with at least one adverse event            3 (3.5%)                                0                               0                      3 (1.2%)
-      5                                                                Total number of events                   3                                0                               0                             3
-      6                                                                              HLT_0148                <NA>                             <NA>                            <NA>                          <NA>
-      7                          Total number of participants with at least one adverse event            3 (3.5%)                                0                               0                      3 (1.2%)
-      8                                                                Total number of events                   3                                0                               0                             3
-      9                                                                             DIARRHOEA            3 (3.5%)                                0                               0                      3 (1.2%)
-      10                                 GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>                          <NA>
-      11                         Total number of participants with at least one adverse event            1 (1.2%)                         2 (2.4%)                        1 (1.2%)                      4 (1.6%)
-      12                                                               Total number of events                   2                                4                               1                             7
-      13                                                                             HLT_0043                <NA>                             <NA>                            <NA>                          <NA>
-      14                         Total number of participants with at least one adverse event                   0                         1 (1.2%)                               0                      1 (0.4%)
-      15                                                               Total number of events                   0                                1                               0                             1
-      16                                                                              FATIGUE                   0                         1 (1.2%)                               0                      1 (0.4%)
-      17                                                                             HLT_0317                <NA>                             <NA>                            <NA>                          <NA>
-      18                         Total number of participants with at least one adverse event            1 (1.2%)                         2 (2.4%)                               0                      3 (1.2%)
-      19                                                               Total number of events                   1                                2                               0                             3
-      20                                                            APPLICATION SITE PRURITUS            1 (1.2%)                         2 (2.4%)                               0                      3 (1.2%)
-      21                                                                             HLT_0617                <NA>                             <NA>                            <NA>                          <NA>
-      22                         Total number of participants with at least one adverse event            1 (1.2%)                         1 (1.2%)                        1 (1.2%)                      3 (1.2%)
-      23                                                               Total number of events                   1                                1                               1                             3
-      24                                                            APPLICATION SITE ERYTHEMA            1 (1.2%)                         1 (1.2%)                        1 (1.2%)                      3 (1.2%)
+         Body System or Organ Class  \n<U+00A0><U+00A0><U+00A0><U+00A0>High Level Term  \n<U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term Placebo  \n(N = 86)
+      1                                                                                                              Total number of participants with at least one adverse event     3<U+00A0>(3.5%)
+      2                                                                                                                                            Overall total number of events                   5
+      3                                                                                                                                                GASTROINTESTINAL DISORDERS                <NA>
+      4                                                                                                              Total number of participants with at least one adverse event     3<U+00A0>(3.5%)
+      5                                                                                                                                                    Total number of events                   3
+      6                                                                                                                                                                  HLT_0148                <NA>
+      7                                                                                                              Total number of participants with at least one adverse event     3<U+00A0>(3.5%)
+      8                                                                                                                                                    Total number of events                   3
+      9                                                                                                                                                                 DIARRHOEA     3<U+00A0>(3.5%)
+      10                                                                                                                     GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>
+      11                                                                                                             Total number of participants with at least one adverse event     1<U+00A0>(1.2%)
+      12                                                                                                                                                   Total number of events                   2
+      13                                                                                                                                                                 HLT_0043                <NA>
+      14                                                                                                             Total number of participants with at least one adverse event                   0
+      15                                                                                                                                                   Total number of events                   0
+      16                                                                                                                                                                  FATIGUE                   0
+      17                                                                                                                                                                 HLT_0317                <NA>
+      18                                                                                                             Total number of participants with at least one adverse event     1<U+00A0>(1.2%)
+      19                                                                                                                                                   Total number of events                   1
+      20                                                                                                                                                APPLICATION SITE PRURITUS     1<U+00A0>(1.2%)
+      21                                                                                                                                                                 HLT_0617                <NA>
+      22                                                                                                             Total number of participants with at least one adverse event     1<U+00A0>(1.2%)
+      23                                                                                                                                                   Total number of events                   1
+      24                                                                                                                                                APPLICATION SITE ERYTHEMA     1<U+00A0>(1.2%)
+         Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84) All Participants  \n(N = 254)
+      1                   2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)               6<U+00A0>(2.4%)
+      2                                 4                               1                            10
+      3                              <NA>                            <NA>                          <NA>
+      4                                 0                               0               3<U+00A0>(1.2%)
+      5                                 0                               0                             3
+      6                              <NA>                            <NA>                          <NA>
+      7                                 0                               0               3<U+00A0>(1.2%)
+      8                                 0                               0                             3
+      9                                 0                               0               3<U+00A0>(1.2%)
+      10                             <NA>                            <NA>                          <NA>
+      11                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)               4<U+00A0>(1.6%)
+      12                                4                               1                             7
+      13                             <NA>                            <NA>                          <NA>
+      14                  1<U+00A0>(1.2%)                               0               1<U+00A0>(0.4%)
+      15                                1                               0                             1
+      16                  1<U+00A0>(1.2%)                               0               1<U+00A0>(0.4%)
+      17                             <NA>                            <NA>                          <NA>
+      18                  2<U+00A0>(2.4%)                               0               3<U+00A0>(1.2%)
+      19                                2                               0                             3
+      20                  2<U+00A0>(2.4%)                               0               3<U+00A0>(1.2%)
+      21                             <NA>                            <NA>                          <NA>
+      22                  1<U+00A0>(1.2%)                 1<U+00A0>(1.2%)               3<U+00A0>(1.2%)
+      23                                1                               1                             3
+      24                  1<U+00A0>(1.2%)                 1<U+00A0>(1.2%)               3<U+00A0>(1.2%)
+
+# tbl_hierarchical_rate_and_count() emits zero-rows for unobserved factor levels
+
+    Code
+      as.data.frame(tbl)
+    Condition
+      Warning in `do.call()`:
+      unable to translate 'AEBODSYS  
+      <U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term' to native encoding
+    Output
+         AEBODSYS  \n<U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84)
+      1         Total number of participants with at least one adverse event     3<U+00A0>(3.5%)                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)
+      2                                       Overall total number of events                   5                                4                               1
+      3                                           GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>
+      4         Total number of participants with at least one adverse event     3<U+00A0>(3.5%)                                0                               0
+      5                                               Total number of events                   3                                0                               0
+      6                                                            DIARRHOEA     3<U+00A0>(3.5%)                                0                               0
+      7                 GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>
+      8         Total number of participants with at least one adverse event     1<U+00A0>(1.2%)                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)
+      9                                               Total number of events                   2                                4                               1
+      10                                           APPLICATION SITE ERYTHEMA     1<U+00A0>(1.2%)                  1<U+00A0>(1.2%)                 1<U+00A0>(1.2%)
+      11                                           APPLICATION SITE PRURITUS     1<U+00A0>(1.2%)                  2<U+00A0>(2.4%)                               0
+      12                                                             FATIGUE                   0                  1<U+00A0>(1.2%)                               0
+      13                                                      UNOBSERVED SOC                <NA>                             <NA>                            <NA>
+      14        Total number of participants with at least one adverse event                   0                                0                               0
+      15                                              Total number of events                   0                                0                               0
+
+# tbl_hierarchical_rate_and_count() handles 0-row data with factor levels
+
+    Code
+      as.data.frame(tbl)
+    Condition
+      Warning in `do.call()`:
+      unable to translate 'AEBODSYS  
+      <U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term' to native encoding
+    Output
+        AEBODSYS  \n<U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term Placebo  \nN = 86 Xanomeline High Dose  \nN = 84 Xanomeline Low Dose  \nN = 84
+      1        Total number of participants with at least one adverse event                 0                              0                             0
+      2                                                               SOC_A              <NA>                           <NA>                          <NA>
+      3        Total number of participants with at least one adverse event                 0                              0                             0
+      4                                              Total number of events                 0                              0                             0
+      5                                                               SOC_B              <NA>                           <NA>                          <NA>
+      6        Total number of participants with at least one adverse event                 0                              0                             0
+      7                                              Total number of events                 0                              0                             0
 
 # tbl_hierarchical_rate_and_count() works only with 2 or 3 variables
 

--- a/tests/testthat/_snaps/tbl_hierarchical_rate_and_count.md
+++ b/tests/testthat/_snaps/tbl_hierarchical_rate_and_count.md
@@ -2,129 +2,87 @@
 
     Code
       as.data.frame(tbl)
-    Condition
-      Warning in `do.call()`:
-      unable to translate 'Body System or Organ Class  
-      <U+00A0><U+00A0><U+00A0><U+00A0>MedDRA Preferred Term' to native encoding
     Output
-         Body System or Organ Class  \n<U+00A0><U+00A0><U+00A0><U+00A0>MedDRA Preferred Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84) All Participants  \n(N = 254)
-      1                         Total number of participants with at least one adverse event     3<U+00A0>(3.5%)                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)               6<U+00A0>(2.4%)
-      2                                                       Overall total number of events                   5                                4                               1                            10
-      3                                                           GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>                          <NA>
-      4                         Total number of participants with at least one adverse event     3<U+00A0>(3.5%)                                0                               0               3<U+00A0>(1.2%)
-      5                                                               Total number of events                   3                                0                               0                             3
-      6                                                                            DIARRHOEA     3<U+00A0>(3.5%)                                0                               0               3<U+00A0>(1.2%)
-      7                                 GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>                          <NA>
-      8                         Total number of participants with at least one adverse event     1<U+00A0>(1.2%)                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)               4<U+00A0>(1.6%)
-      9                                                               Total number of events                   2                                4                               1                             7
-      10                                                           APPLICATION SITE ERYTHEMA     1<U+00A0>(1.2%)                  1<U+00A0>(1.2%)                 1<U+00A0>(1.2%)               3<U+00A0>(1.2%)
-      11                                                           APPLICATION SITE PRURITUS     1<U+00A0>(1.2%)                  2<U+00A0>(2.4%)                               0               3<U+00A0>(1.2%)
-      12                                                                             FATIGUE                   0                  1<U+00A0>(1.2%)                               0               1<U+00A0>(0.4%)
+              Body System or Organ Class  \n    MedDRA Preferred Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84) All Participants  \n(N = 254)
+      1  Total number of participants with at least one adverse event            3 (3.5%)                         2 (2.4%)                        1 (1.2%)                      6 (2.4%)
+      2                                Overall total number of events                   5                                4                               1                            10
+      3                                    GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>                          <NA>
+      4  Total number of participants with at least one adverse event            3 (3.5%)                                0                               0                      3 (1.2%)
+      5                                        Total number of events                   3                                0                               0                             3
+      6                                                     DIARRHOEA            3 (3.5%)                                0                               0                      3 (1.2%)
+      7          GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>                          <NA>
+      8  Total number of participants with at least one adverse event            1 (1.2%)                         2 (2.4%)                        1 (1.2%)                      4 (1.6%)
+      9                                        Total number of events                   2                                4                               1                             7
+      10                                    APPLICATION SITE ERYTHEMA            1 (1.2%)                         1 (1.2%)                        1 (1.2%)                      3 (1.2%)
+      11                                    APPLICATION SITE PRURITUS            1 (1.2%)                         2 (2.4%)                               0                      3 (1.2%)
+      12                                                      FATIGUE                   0                         1 (1.2%)                               0                      1 (0.4%)
 
 ---
 
     Code
       as.data.frame(tbl)
-    Condition
-      Warning in `do.call()`:
-      unable to translate 'Body System or Organ Class  
-      <U+00A0><U+00A0><U+00A0><U+00A0>High Level Term  
-      <U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term' to native encoding
     Output
-         Body System or Organ Class  \n<U+00A0><U+00A0><U+00A0><U+00A0>High Level Term  \n<U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term Placebo  \n(N = 86)
-      1                                                                                                              Total number of participants with at least one adverse event     3<U+00A0>(3.5%)
-      2                                                                                                                                            Overall total number of events                   5
-      3                                                                                                                                                GASTROINTESTINAL DISORDERS                <NA>
-      4                                                                                                              Total number of participants with at least one adverse event     3<U+00A0>(3.5%)
-      5                                                                                                                                                    Total number of events                   3
-      6                                                                                                                                                                  HLT_0148                <NA>
-      7                                                                                                              Total number of participants with at least one adverse event     3<U+00A0>(3.5%)
-      8                                                                                                                                                    Total number of events                   3
-      9                                                                                                                                                                 DIARRHOEA     3<U+00A0>(3.5%)
-      10                                                                                                                     GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>
-      11                                                                                                             Total number of participants with at least one adverse event     1<U+00A0>(1.2%)
-      12                                                                                                                                                   Total number of events                   2
-      13                                                                                                                                                                 HLT_0043                <NA>
-      14                                                                                                             Total number of participants with at least one adverse event                   0
-      15                                                                                                                                                   Total number of events                   0
-      16                                                                                                                                                                  FATIGUE                   0
-      17                                                                                                                                                                 HLT_0317                <NA>
-      18                                                                                                             Total number of participants with at least one adverse event     1<U+00A0>(1.2%)
-      19                                                                                                                                                   Total number of events                   1
-      20                                                                                                                                                APPLICATION SITE PRURITUS     1<U+00A0>(1.2%)
-      21                                                                                                                                                                 HLT_0617                <NA>
-      22                                                                                                             Total number of participants with at least one adverse event     1<U+00A0>(1.2%)
-      23                                                                                                                                                   Total number of events                   1
-      24                                                                                                                                                APPLICATION SITE ERYTHEMA     1<U+00A0>(1.2%)
-         Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84) All Participants  \n(N = 254)
-      1                   2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)               6<U+00A0>(2.4%)
-      2                                 4                               1                            10
-      3                              <NA>                            <NA>                          <NA>
-      4                                 0                               0               3<U+00A0>(1.2%)
-      5                                 0                               0                             3
-      6                              <NA>                            <NA>                          <NA>
-      7                                 0                               0               3<U+00A0>(1.2%)
-      8                                 0                               0                             3
-      9                                 0                               0               3<U+00A0>(1.2%)
-      10                             <NA>                            <NA>                          <NA>
-      11                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)               4<U+00A0>(1.6%)
-      12                                4                               1                             7
-      13                             <NA>                            <NA>                          <NA>
-      14                  1<U+00A0>(1.2%)                               0               1<U+00A0>(0.4%)
-      15                                1                               0                             1
-      16                  1<U+00A0>(1.2%)                               0               1<U+00A0>(0.4%)
-      17                             <NA>                            <NA>                          <NA>
-      18                  2<U+00A0>(2.4%)                               0               3<U+00A0>(1.2%)
-      19                                2                               0                             3
-      20                  2<U+00A0>(2.4%)                               0               3<U+00A0>(1.2%)
-      21                             <NA>                            <NA>                          <NA>
-      22                  1<U+00A0>(1.2%)                 1<U+00A0>(1.2%)               3<U+00A0>(1.2%)
-      23                                1                               1                             3
-      24                  1<U+00A0>(1.2%)                 1<U+00A0>(1.2%)               3<U+00A0>(1.2%)
+         Body System or Organ Class  \n    High Level Term  \n        Dictionary-Derived Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84) All Participants  \n(N = 254)
+      1                          Total number of participants with at least one adverse event            3 (3.5%)                         2 (2.4%)                        1 (1.2%)                      6 (2.4%)
+      2                                                        Overall total number of events                   5                                4                               1                            10
+      3                                                            GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>                          <NA>
+      4                          Total number of participants with at least one adverse event            3 (3.5%)                                0                               0                      3 (1.2%)
+      5                                                                Total number of events                   3                                0                               0                             3
+      6                                                                              HLT_0148                <NA>                             <NA>                            <NA>                          <NA>
+      7                          Total number of participants with at least one adverse event            3 (3.5%)                                0                               0                      3 (1.2%)
+      8                                                                Total number of events                   3                                0                               0                             3
+      9                                                                             DIARRHOEA            3 (3.5%)                                0                               0                      3 (1.2%)
+      10                                 GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>                          <NA>
+      11                         Total number of participants with at least one adverse event            1 (1.2%)                         2 (2.4%)                        1 (1.2%)                      4 (1.6%)
+      12                                                               Total number of events                   2                                4                               1                             7
+      13                                                                             HLT_0043                <NA>                             <NA>                            <NA>                          <NA>
+      14                         Total number of participants with at least one adverse event                   0                         1 (1.2%)                               0                      1 (0.4%)
+      15                                                               Total number of events                   0                                1                               0                             1
+      16                                                                              FATIGUE                   0                         1 (1.2%)                               0                      1 (0.4%)
+      17                                                                             HLT_0317                <NA>                             <NA>                            <NA>                          <NA>
+      18                         Total number of participants with at least one adverse event            1 (1.2%)                         2 (2.4%)                               0                      3 (1.2%)
+      19                                                               Total number of events                   1                                2                               0                             3
+      20                                                            APPLICATION SITE PRURITUS            1 (1.2%)                         2 (2.4%)                               0                      3 (1.2%)
+      21                                                                             HLT_0617                <NA>                             <NA>                            <NA>                          <NA>
+      22                         Total number of participants with at least one adverse event            1 (1.2%)                         1 (1.2%)                        1 (1.2%)                      3 (1.2%)
+      23                                                               Total number of events                   1                                1                               1                             3
+      24                                                            APPLICATION SITE ERYTHEMA            1 (1.2%)                         1 (1.2%)                        1 (1.2%)                      3 (1.2%)
 
 # tbl_hierarchical_rate_and_count() emits zero-rows for unobserved factor levels
 
     Code
       as.data.frame(tbl)
-    Condition
-      Warning in `do.call()`:
-      unable to translate 'AEBODSYS  
-      <U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term' to native encoding
     Output
-         AEBODSYS  \n<U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84)
-      1         Total number of participants with at least one adverse event     3<U+00A0>(3.5%)                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)
-      2                                       Overall total number of events                   5                                4                               1
-      3                                           GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>
-      4         Total number of participants with at least one adverse event     3<U+00A0>(3.5%)                                0                               0
-      5                                               Total number of events                   3                                0                               0
-      6                                                            DIARRHOEA     3<U+00A0>(3.5%)                                0                               0
-      7                 GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>
-      8         Total number of participants with at least one adverse event     1<U+00A0>(1.2%)                  2<U+00A0>(2.4%)                 1<U+00A0>(1.2%)
-      9                                               Total number of events                   2                                4                               1
-      10                                           APPLICATION SITE ERYTHEMA     1<U+00A0>(1.2%)                  1<U+00A0>(1.2%)                 1<U+00A0>(1.2%)
-      11                                           APPLICATION SITE PRURITUS     1<U+00A0>(1.2%)                  2<U+00A0>(2.4%)                               0
-      12                                                             FATIGUE                   0                  1<U+00A0>(1.2%)                               0
-      13                                                      UNOBSERVED SOC                <NA>                             <NA>                            <NA>
-      14        Total number of participants with at least one adverse event                   0                                0                               0
-      15                                              Total number of events                   0                                0                               0
+                              AEBODSYS  \n    Dictionary-Derived Term Placebo  \n(N = 86) Xanomeline High Dose  \n(N = 84) Xanomeline Low Dose  \n(N = 84)
+      1  Total number of participants with at least one adverse event            3 (3.5%)                         2 (2.4%)                        1 (1.2%)
+      2                                Overall total number of events                   5                                4                               1
+      3                                    GASTROINTESTINAL DISORDERS                <NA>                             <NA>                            <NA>
+      4  Total number of participants with at least one adverse event            3 (3.5%)                                0                               0
+      5                                        Total number of events                   3                                0                               0
+      6                                                     DIARRHOEA            3 (3.5%)                                0                               0
+      7          GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS                <NA>                             <NA>                            <NA>
+      8  Total number of participants with at least one adverse event            1 (1.2%)                         2 (2.4%)                        1 (1.2%)
+      9                                        Total number of events                   2                                4                               1
+      10                                    APPLICATION SITE ERYTHEMA            1 (1.2%)                         1 (1.2%)                        1 (1.2%)
+      11                                    APPLICATION SITE PRURITUS            1 (1.2%)                         2 (2.4%)                               0
+      12                                                      FATIGUE                   0                         1 (1.2%)                               0
+      13                                               UNOBSERVED SOC                <NA>                             <NA>                            <NA>
+      14 Total number of participants with at least one adverse event                   0                                0                               0
+      15                                       Total number of events                   0                                0                               0
 
 # tbl_hierarchical_rate_and_count() handles 0-row data with factor levels
 
     Code
       as.data.frame(tbl)
-    Condition
-      Warning in `do.call()`:
-      unable to translate 'AEBODSYS  
-      <U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term' to native encoding
     Output
-        AEBODSYS  \n<U+00A0><U+00A0><U+00A0><U+00A0>Dictionary-Derived Term Placebo  \nN = 86 Xanomeline High Dose  \nN = 84 Xanomeline Low Dose  \nN = 84
-      1        Total number of participants with at least one adverse event                 0                              0                             0
-      2                                                               SOC_A              <NA>                           <NA>                          <NA>
-      3        Total number of participants with at least one adverse event                 0                              0                             0
-      4                                              Total number of events                 0                              0                             0
-      5                                                               SOC_B              <NA>                           <NA>                          <NA>
-      6        Total number of participants with at least one adverse event                 0                              0                             0
-      7                                              Total number of events                 0                              0                             0
+                             AEBODSYS  \n    Dictionary-Derived Term Placebo  \nN = 86 Xanomeline High Dose  \nN = 84 Xanomeline Low Dose  \nN = 84
+      1 Total number of participants with at least one adverse event                 0                              0                             0
+      2                                                        SOC_A              <NA>                           <NA>                          <NA>
+      3 Total number of participants with at least one adverse event                 0                              0                             0
+      4                                       Total number of events                 0                              0                             0
+      5                                                        SOC_B              <NA>                           <NA>                          <NA>
+      6 Total number of participants with at least one adverse event                 0                              0                             0
+      7                                       Total number of events                 0                              0                             0
 
 # tbl_hierarchical_rate_and_count() works only with 2 or 3 variables
 

--- a/tests/testthat/test-tbl_hierarchical_rate_and_count.R
+++ b/tests/testthat/test-tbl_hierarchical_rate_and_count.R
@@ -100,6 +100,121 @@ test_that("tbl_hierarchical_rate_and_count() digits styling defaults to gtsummar
   )
 })
 
+test_that("tbl_hierarchical_rate_and_count() emits zero-rows for unobserved factor levels", {
+  withr::local_options(list(width = 220))
+
+  adae_factor <- ADAE_subset |>
+    dplyr::mutate(
+      AEBODSYS = factor(
+        AEBODSYS,
+        levels = c(unique(AEBODSYS), "UNOBSERVED SOC")
+      )
+    )
+
+  tbl <- adae_factor |>
+    tbl_hierarchical_rate_and_count(
+      denominator = cards::ADSL,
+      by = TRTA,
+      variables = c(AEBODSYS, AEDECOD)
+    )
+
+  # the unobserved level appears in the table body
+  expect_true("UNOBSERVED SOC" %in% tbl$table_body$label)
+
+  # zero-rows have the correct structure: header (NA) + rate ("0") + count ("0")
+  unobs_rows <- tbl$table_body |>
+    dplyr::filter(.data$group1_level == "UNOBSERVED SOC")
+
+  expect_equal(nrow(unobs_rows), 3L)
+  expect_equal(unobs_rows$label[1], "UNOBSERVED SOC")
+  expect_true(is.na(unobs_rows$stat_1[1]))
+  expect_equal(unobs_rows$stat_1[2], "0")
+  expect_equal(unobs_rows$stat_1[3], "0")
+
+  # add_overall populates the overall column with "0" for zero-rows
+  tbl_overall <- tbl |> add_overall(last = TRUE)
+  unobs_overall <- tbl_overall$table_body |>
+    dplyr::filter(.data$group1_level == "UNOBSERVED SOC")
+  expect_equal(unobs_overall$stat_0[2], "0")
+
+  expect_snapshot(as.data.frame(tbl))
+})
+
+test_that("tbl_hierarchical_rate_and_count() ignores non-factor variables", {
+  # character AEBODSYS should not trigger zero-row injection
+  tbl_char <- ADAE_subset |>
+    dplyr::mutate(AEBODSYS = as.character(AEBODSYS)) |>
+    tbl_hierarchical_rate_and_count(
+      denominator = cards::ADSL,
+      by = TRTA,
+      variables = c(AEBODSYS, AEDECOD)
+    )
+
+  tbl_no_factor <- ADAE_subset |>
+    tbl_hierarchical_rate_and_count(
+      denominator = cards::ADSL,
+      by = TRTA,
+      variables = c(AEBODSYS, AEDECOD)
+    )
+
+  # both should produce identical output (no extra rows)
+  expect_equal(nrow(tbl_char$table_body), nrow(tbl_no_factor$table_body))
+})
+
+test_that("tbl_hierarchical_rate_and_count() handles 0-row data with factor levels", {
+  withr::local_options(list(width = 220))
+
+  empty_adae <- ADAE_subset |>
+    dplyr::filter(FALSE) |>
+    dplyr::mutate(
+      AEBODSYS = factor(character(0), levels = c("SOC_A", "SOC_B"))
+    )
+
+  tbl <- empty_adae |>
+    tbl_hierarchical_rate_and_count(
+      denominator = cards::ADSL,
+      by = TRTA,
+      variables = c(AEBODSYS, AEDECOD),
+      label_overall_count = "remove"
+    )
+
+  # overall rate + 2 baskets * (header + rate + count) = 7 rows
+  expect_equal(nrow(tbl$table_body), 7L)
+
+  # all stat values are either "0" or NA (headers)
+  stat_vals <- unlist(tbl$table_body[grep("^stat_", names(tbl$table_body))])
+  expect_true(all(stat_vals %in% c("0", NA_character_)))
+
+  # class is preserved
+
+  expect_s3_class(tbl, "tbl_hierarchical_rate_and_count")
+
+  expect_snapshot(as.data.frame(tbl))
+})
+
+test_that("tbl_hierarchical_rate_and_count() zero-rows work with by = NULL", {
+  adae_factor <- ADAE_subset |>
+    dplyr::mutate(
+      AEBODSYS = factor(
+        AEBODSYS,
+        levels = c(unique(AEBODSYS), "EMPTY SOC")
+      )
+    )
+
+  tbl <- adae_factor |>
+    tbl_hierarchical_rate_and_count(
+      denominator = cards::ADSL,
+      variables = c(AEBODSYS, AEDECOD)
+    )
+
+  unobs_rows <- tbl$table_body |>
+    dplyr::filter(.data$group1_level == "EMPTY SOC")
+
+  expect_equal(nrow(unobs_rows), 3L)
+  expect_equal(unobs_rows$stat_0[2], "0")
+  expect_equal(unobs_rows$stat_0[3], "0")
+})
+
 test_that("tbl_hierarchical_rate_and_count() works only with 2 or 3 variables", {
   expect_snapshot(
     tbl <-


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `tbl_hierarchical_rate_and_count()` now emits zero-rows for unobserved factor levels in the first hierarchical variable. (#233, @Melkiades)

When `variables[1]` is a factor, any levels not present in the data get a header row (NA stats), a rate summary row ("0"), and a count summary row ("0") appended to the table. This eliminates the need for dummy-data workarounds in templates where some hierarchical groups may have no matching events (e.g., empty SMQ baskets in AET02_SMQ).

The implementation is a post-processing step (`.inject_unobserved_levels()`) that runs after the table is fully built. Non-factor variables are ignored — existing behavior is unchanged.

**Reference GitHub issue associated with pull request.** closes #233

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer