### PR TITLE
feat: `tbl_roche_subgroups()` shows event counts for time-to-event

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,8 @@ all events (#217)
 
 * Adjusted `modify_zero_recode()` to account for strings comprising regular and non-breaking spaces (#230)
 
+* `tbl_roche_subgroups()` now shows `n`, `Events`, and `Median` per arm when `time_to_event` is specified. The total column shows `Total Events` instead of `Total n`. (#235)
+
 # crane 0.3.1
 
 ## New Functions and Functionality

--- a/R/tbl_roche_subgroups.R
+++ b/R/tbl_roche_subgroups.R
@@ -98,17 +98,27 @@ tbl_roche_subgroups <- function(data, rsp, by, subgroups, .tbl_fun, time_to_even
     all_vars |>
     map(
       \(x) {
+        is_tte <- length(time_to_event) > 0
         list(
-          # total n
+          # total n (binary) or total events (time-to-event)
           gtsummary::tbl_strata(
             data = data_aug,
             strata = dplyr::all_of(x),
-            .tbl_fun = ~ .x |>
-              gtsummary::tbl_summary(
-                include = dplyr::all_of(rsp),
-                statistic = gtsummary::everything() ~ "{N}",
-                missing = "no"
-              ),
+            .tbl_fun = if (is_tte) {
+              ~ .x |>
+                gtsummary::tbl_summary(
+                  include = dplyr::all_of(rsp),
+                  statistic = gtsummary::everything() ~ "{n}",
+                  missing = "no"
+                )
+            } else {
+              ~ .x |>
+                gtsummary::tbl_summary(
+                  include = dplyr::all_of(rsp),
+                  statistic = gtsummary::everything() ~ "{N}",
+                  missing = "no"
+                )
+            },
             .combine_with = "tbl_stack",
             .combine_args = if (x == "..overall..") {
               list(group_header = NULL, quiet = TRUE)
@@ -116,7 +126,9 @@ tbl_roche_subgroups <- function(data, rsp, by, subgroups, .tbl_fun, time_to_even
               list(quiet = TRUE)
             }
           ) |>
-            gtsummary::modify_header(stat_0 ~ "**Total n**"),
+            gtsummary::modify_header(
+              stat_0 ~ ifelse(is_tte, "**Total Events**", "**Total n**")
+            ),
           # responder or time-to-event median statistics
           gtsummary::tbl_strata(
             data = data_aug,
@@ -192,22 +204,43 @@ tbl_roche_subgroups <- function(data, rsp, by, subgroups, .tbl_fun, time_to_even
 }
 
 
-# Define a function to apply the .tbl_fun to each subgroup
+# Build the per-arm summary table for the middle section of tbl_roche_subgroups.
+# For binary outcomes: n Response (%)
+# For time-to-event: n, Events, Median
 .make_mid_tbl <- function(dt, vars) {
   if ("time_to_event" %in% names(vars) && length(vars[["time_to_event"]]) > 0) {
-    out <- dt |>
-      # Use ard_continuous instead of ard_tabulate_value
-      cards::ard_continuous(
-        variables = dplyr::all_of(vars[["time_to_event"]]),
-        stat_label = cards::everything() ~ list(N = "n", median = "Median")
-        # ard_continuous calculates N, mean, median, min, max, etc. by default
-      ) |>
+    rsp_var <- vars[["rsp"]]
+    tte_var <- vars[["time_to_event"]]
+
+    # N and median from the time-to-event variable
+    ard_tte <- cards::ard_continuous(
+      dt,
+      variables = dplyr::all_of(tte_var),
+      stat_label = cards::everything() ~ list(N = "n")
+    )
+
+    # Event count from the response indicator
+    ard_events <- cards::ard_tabulate_value(
+      dt,
+      variables = dplyr::all_of(rsp_var),
+      stat_label = cards::everything() ~ list(n = "Events")
+    )
+    # Align variable name so tbl_ard_wide_summary treats them as one row
+    ard_events$variable <- tte_var
+
+    ard_combined <- dplyr::bind_rows(ard_tte, ard_events) |>
+      dplyr::filter(.data$stat_name %in% c("N", "n", "median"))
+
+    out <- ard_combined |>
       gtsummary::tbl_ard_wide_summary(
-        include = dplyr::all_of(vars[["time_to_event"]]),
-        # Call the specific continuous statistics here
-        statistic = c("{N}", "{median}")
+        include = dplyr::all_of(tte_var),
+        statistic = c("{N}", "{n}", "{median}")
       ) |>
-      gtsummary::modify_header(stat_2 ~ "**Median (Months)**")
+      gtsummary::modify_header(
+        stat_1 ~ "**n**",
+        stat_2 ~ "**Events**",
+        stat_3 ~ "**Median (Months)**"
+      )
   } else {
     out <- dt |>
       cards::ard_tabulate_value(
@@ -218,7 +251,6 @@ tbl_roche_subgroups <- function(data, rsp, by, subgroups, .tbl_fun, time_to_even
         include = dplyr::all_of(vars[["rsp"]]),
         statistic = "{N} ({p} %)"
       ) |>
-      # Explicitly renames the column header itself
       gtsummary::modify_header(gtsummary::all_stat_cols() ~ "**n Response (%)**")
   }
 

--- a/R/tbl_roche_subgroups.R
+++ b/R/tbl_roche_subgroups.R
@@ -11,8 +11,9 @@
 #' @param subgroups ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
 #'   Variables to perform stratified analyses for.
 #' @param time_to_event ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
-#'   Variable to use in time-to-event analyses. If specified, the mid table will
-#'   show the median time-to-event instead of responder rates.
+#'   Variable to use in time-to-event analyses. If specified, the mid table
+#'   shows n (subjects), Events (from `rsp`), and Median per arm instead of
+#'   responder rates. The total column shows Total Events instead of Total n.
 #'
 #' @returns a 'gtsummary' table
 #'

--- a/man/tbl_roche_subgroups.Rd
+++ b/man/tbl_roche_subgroups.Rd
@@ -25,8 +25,9 @@ If a formula, e.g. \code{~ .x \%>\% tbl_summary() \%>\% add_p()}, it is converte
 The stratified data frame is passed to this function.}
 
 \item{time_to_event}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-Variable to use in time-to-event analyses. If specified, the mid table will
-show the median time-to-event instead of responder rates.}
+Variable to use in time-to-event analyses. If specified, the mid table
+shows n (subjects), Events (from \code{rsp}), and Median per arm instead of
+responder rates. The total column shows Total Events instead of Total n.}
 }
 \value{
 a 'gtsummary' table

--- a/tests/testthat/_snaps/tbl_roche_subgroups.md
+++ b/tests/testthat/_snaps/tbl_roche_subgroups.md
@@ -26,15 +26,15 @@
       dplyr::select(tbl$table_body, dplyr::starts_with("label"), dplyr::starts_with(
         "stat"))
     Output
-      # A tibble: 7 x 9
-        label_1   label_2 label_3 stat_0_1 stat_1_1_2 stat_2_1_2 stat_1_2_2 stat_2_2_2
+      # A tibble: 7 x 11
+        label_1   label_2 label_3 stat_0_1 stat_1_1_2 stat_2_1_2 stat_3_1_2 stat_1_2_2
         <glue>    <chr>   <chr>   <chr>    <chr>      <chr>      <chr>      <chr>     
-      1 All Part~ time    X1      10       5          9.0        5          9.2       
+      1 All Part~ time    X1      5        5          3          9.0        5         
       2 grade     <NA>    <NA>    <NA>     <NA>       <NA>       <NA>       <NA>      
-      3 I         time    X1      5        2          5.0        3          9.2       
-      4 II        time    X1      5        3          13.4       2          33.8      
+      3 I         time    X1      2        2          1          5.0        3         
+      4 II        time    X1      3        3          2          13.4       2         
       5 strata    <NA>    <NA>    <NA>     <NA>       <NA>       <NA>       <NA>      
-      6 1         time    X1      5        3          13.4       2          33.8      
-      7 2         time    X1      5        2          5.0        3          9.2       
-      # i 1 more variable: stat_0_3 <chr>
+      6 1         time    X1      3        3          2          13.4       2         
+      7 2         time    X1      2        2          1          5.0        3         
+      # i 3 more variables: stat_2_2_2 <chr>, stat_3_2_2 <chr>, stat_0_3 <chr>
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `tbl_roche_subgroups()` now shows `n` (subjects), `Events` (event count), and `Median` per arm when `time_to_event` is specified. The total column shows `Total Events` instead of `Total n`. (#235, @Melkiades)

Previously, the mid table for time-to-event only showed `N` and `Median`. Templates (e.g., FSTG02) had to manually compute event counts and inject them via `modify_table_body()` with hardcoded column names — fragile and limited to exactly 2 arms.

The fix modifies `.make_mid_tbl()` to combine `ard_continuous` (for N and median) with `ard_tabulate_value` (for event count from the `rsp` variable). The total row uses `{n}` (event count) instead of `{N}` (subject count) when `time_to_event` is present.

**Reference GitHub issue associated with pull request.** closes #235

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer