### PR TITLE
feat: expose `overall_row`, `add_overall()`, and spanning headers for `tbl_hierarchical_incidence_rate()`

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(add_difference_row,tbl_survfit_times)
 S3method(add_overall,tbl_baseline_chg)
+S3method(add_overall,tbl_hierarchical_incidence_rate)
 S3method(add_overall,tbl_hierarchical_rate_and_count)
 S3method(add_overall,tbl_hierarchical_rate_by_grade)
 S3method(add_overall,tbl_rmpt)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,9 @@
 
 * `tbl_hierarchical_incidence_rate()` gains an `overall_row` argument to control whether the overall summary row is included. (#264)
 
-* `tbl_hierarchical_incidence_rate()` now supports `add_overall()` to append an unstratified "Overall" column pooling all treatment arms. (#264)
+* `tbl_hierarchical_incidence_rate()` now supports `add_overall()` to append an unstratified column pooling all treatment arms, consistent with the other `add_overall()` methods in the package (`last = FALSE` and a glue `col_label` by default). (#264)
 
-* `tbl_hierarchical_incidence_rate()` now renders spanning headers for treatment arm columns. (#264)
+* `tbl_hierarchical_incidence_rate()` now renders spanning headers for treatment arm columns, customizable via the new `spanning_label` glue argument (e.g. `"{level} (N = {n})"`). (#264)
 
 # crane 0.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # crane 0.3.2.9000
 
+* `tbl_hierarchical_incidence_rate()` gains an `overall_row` argument to control whether the overall summary row is included. (#264)
+
+* `tbl_hierarchical_incidence_rate()` now supports `add_overall()` to append an unstratified "Overall" column pooling all treatment arms. (#264)
+
+* `tbl_hierarchical_incidence_rate()` now renders spanning headers for treatment arm columns. (#264)
+
 # crane 0.3.2
 
 ## New Functions and Functionality

--- a/R/tbl_hierarchical_incidence_rate.R
+++ b/R/tbl_hierarchical_incidence_rate.R
@@ -397,10 +397,11 @@ tbl_hierarchical_incidence_rate <- function(data,
 #' @rdname tbl_hierarchical_incidence_rate
 #' @export
 add_overall.tbl_hierarchical_incidence_rate <- function(
-    x,
-    last = FALSE,
-    col_label = "All Participants  \n(N = {style_roche_number(N)})",
-    ...) {
+  x,
+  last = FALSE,
+  col_label = "All Participants  \n(N = {style_roche_number(N)})",
+  ...
+) {
   # check inputs ---------------------------------------------------------------
   set_cli_abort_call()
   check_dots_empty(call = get_cli_abort_call())

--- a/R/tbl_hierarchical_incidence_rate.R
+++ b/R/tbl_hierarchical_incidence_rate.R
@@ -48,6 +48,21 @@
 #'   Whether to include an overall summary row aggregating across all
 #'   hierarchical levels. Default is `TRUE`. The overall row label can be
 #'   customized via `label = list("..ard_hierarchical_overall.." = "Custom Label")`.
+#' @param spanning_label (`string`)\cr
+#'   A [glue][glue::glue]-style template for the per-arm spanning headers when
+#'   `by` is supplied. Available substitutions are `{level}` (the arm level) and
+#'   `{n}` (the arm participant count). Default is `"{level}  \\n(N = {n})"`,
+#'   matching the column-header convention used elsewhere in the package.
+#' @param x (`tbl_hierarchical_incidence_rate`)\cr
+#'   A table created with [tbl_hierarchical_incidence_rate()].
+#' @param last (`logical(1)`)\cr
+#'   When `add_overall()` is used, whether to place the overall columns after
+#'   (`TRUE`) or before (`FALSE`) the stratified columns. Default is `FALSE`.
+#' @param col_label (`string`)\cr
+#'   A [glue][glue::glue]-style template for the overall spanning header added by
+#'   `add_overall()`. Resolved against the column header context (e.g. `{N}`,
+#'   `{n}`). Default is `"All Participants  \\n(N = {style_roche_number(N)})"`.
+#' @param ... These dots are for future extensions and must be empty.
 #'
 #' @returns a gtsummary table of class `"tbl_hierarchical_incidence_rate"`.
 #' @name tbl_hierarchical_incidence_rate
@@ -126,7 +141,7 @@
 #' ) |>
 #'   add_overall()
 #'
-#' # Customize spanning headers after table creation
+#' # Customize the per-arm spanning headers with a glue template
 #' tbl_hierarchical_incidence_rate(
 #'   data = adae,
 #'   denominator = adsl,
@@ -134,12 +149,9 @@
 #'   by = ARM,
 #'   start_date = TRTSDT,
 #'   end_date = TRTEDT,
-#'   event_date = AESTDTC
-#' ) |>
-#'   gtsummary::modify_spanning_header(
-#'     tidyselect::starts_with("stat_1") ~ "Placebo (N = 3)",
-#'     tidyselect::starts_with("stat_2") ~ "Treatment (N = 2)"
-#'   )
+#'   event_date = AESTDTC,
+#'   spanning_label = "{level} (N = {n})"
+#' )
 #'
 #' @export
 tbl_hierarchical_incidence_rate <- function(data,
@@ -157,7 +169,9 @@ tbl_hierarchical_incidence_rate <- function(data,
                                             conf.type = "normal",
                                             digits = 2,
                                             overall_row = TRUE,
+                                            spanning_label = "{level}  \n(N = {n})",
                                             label = NULL) {
+  set_cli_abort_call()
   # 1. Base Input Validation (Missingness and standard classes)
   event_type <- rlang::arg_match(event_type)
 
@@ -177,8 +191,9 @@ tbl_hierarchical_incidence_rate <- function(data,
   check_numeric(digits)
   check_scalar(digits)
   check_scalar_logical(overall_row)
+  check_string(spanning_label)
   if (!is.null(label) && !is.list(label)) {
-    cli::cli_abort("{.arg label} must be a list or NULL.")
+    cli::cli_abort("{.arg label} must be a list or NULL.", call = get_cli_abort_call())
   }
 
   # 2. Process Tidy-Select Arguments (Evaluates unquoted inputs to strings)
@@ -200,16 +215,13 @@ tbl_hierarchical_incidence_rate <- function(data,
   check_scalar(end_date)
   check_scalar(event_date)
 
-  tbl_final <- list()
+  # Save inputs and call arguments for downstream methods (e.g. add_overall())
+  inputs <- as.list(environment())
 
   # Extract overall label BEFORE `cards` processes the dataset
-
-  overall_label <- NULL
-  if (overall_row) {
-    overall_label <- "All Adverse Events"
-    if (is.list(label) && "..ard_hierarchical_overall.." %in% names(label)) {
-      overall_label <- label[["..ard_hierarchical_overall.."]]
-    }
+  overall_label <- "All Adverse Events"
+  if (is.list(label) && "..ard_hierarchical_overall.." %in% names(label)) {
+    overall_label <- label[["..ard_hierarchical_overall.."]]
   }
 
   # 5. Auto-extract Labels for Dataset Columns
@@ -237,16 +249,16 @@ tbl_hierarchical_incidence_rate <- function(data,
     )
 
   if (overall_row) {
+    # `tbl_hierarchical(overall_row = TRUE)` generates a default label for the
+    # overall row; override it with the user-specified label (if any).
     tbl_base <- tbl_base |>
       gtsummary::modify_table_body(~ .x |> dplyr::mutate(
         label = dplyr::if_else(
           dplyr::row_number() == 1, .env$overall_label, .data$label
         )
       ))
-  }
 
-  # Generate ARDs cleanly using explicit piping
-  if (overall_row) {
+    # Generate the overall (unstratified-across-hierarchy) ARD
     ard_overall <- .prep_incidence_rate_data(
       data, denominator, id, by, start_date,
       end_date, event_date, event_type, NULL
@@ -349,17 +361,22 @@ tbl_hierarchical_incidence_rate <- function(data,
     }) |>
     gtsummary::remove_footnote_header(tidyselect::everything())
 
-  # Apply spanning headers from the arm mapping (e.g., stat_1_* -> "Placebo\nN = 3")
+  # Apply per-arm spanning headers. The label is a glue template resolved with
+  # `level` (arm level) and `n` (arm participant count), e.g. "Placebo  \n(N = 3)".
   if (!is.null(by) && nrow(arm_header_map) > 0L) {
     spanning_formulas <- lapply(seq_len(nrow(arm_header_map)), function(i) {
       arm_idx <- sub("^stat_", "", arm_header_map$column[i])
-      arm_level <- arm_header_map$modify_stat_level[i]
-      arm_n <- arm_header_map$modify_stat_n[i]
       prefix <- paste0("stat_", arm_idx, "_")
-      spanner_label <- paste0(arm_level, "\nN = ", arm_n)
+      spanner_label <- glue::glue_data(
+        list(
+          level = arm_header_map$modify_stat_level[i],
+          n = arm_header_map$modify_stat_n[i]
+        ),
+        spanning_label
+      )
       rlang::new_formula(
         lhs = rlang::expr(tidyselect::starts_with(!!prefix)),
-        rhs = rlang::expr(!!spanner_label)
+        rhs = rlang::expr(!!as.character(spanner_label))
       )
     })
 
@@ -368,11 +385,8 @@ tbl_hierarchical_incidence_rate <- function(data,
     )
   }
 
-  # Store inputs for add_overall() reconstruction
-  tbl_final$inputs <- mget(
-    names(formals(tbl_hierarchical_incidence_rate)),
-    envir = environment()
-  )
+  # Save inputs and call arguments for downstream methods (e.g. add_overall())
+  tbl_final$inputs <- inputs
   tbl_final$call_list <- list(tbl_hierarchical_incidence_rate = match.call())
 
   class(tbl_final) <- c("tbl_hierarchical_incidence_rate", class(tbl_final))
@@ -380,100 +394,93 @@ tbl_hierarchical_incidence_rate <- function(data,
   tbl_final
 }
 
-#' @param x (`tbl_hierarchical_incidence_rate`)\cr
-#'   a table created with [tbl_hierarchical_incidence_rate()].
-#' @param last (`logical(1)`)\cr
-#'   whether to place the overall column last. Default is `TRUE`.
-#' @param col_label (`string`)\cr
-#'   label for the overall column. Default is `"Overall\nN = {style_number(N)}"`.
-#' @param ... These dots are for future extensions and must be empty.
-#'
 #' @rdname tbl_hierarchical_incidence_rate
 #' @export
 add_overall.tbl_hierarchical_incidence_rate <- function(
-  x,
-  last = TRUE,
-  col_label = "Overall\nN = {style_number(N)}",
-  ...
-) {
-  rlang::check_dots_empty()
+    x,
+    last = FALSE,
+    col_label = "All Participants  \n(N = {style_roche_number(N)})",
+    ...) {
+  # check inputs ---------------------------------------------------------------
+  set_cli_abort_call()
+  check_dots_empty(call = get_cli_abort_call())
+  check_string(col_label)
+  check_scalar_logical(last)
 
-  if (is.null(x$inputs[["by"]]) || length(x$inputs[["by"]]) == 0L) {
-    cli::cli_inform(c(
-      "Cannot add an overall column when the table has no {.arg by} variable.",
-      i = "Returning table unaltered."
-    ))
+  if (is_empty(x$inputs[["by"]])) {
+    cli::cli_inform(
+      c("Original table was not stratified, and overall columns cannot be added.",
+        i = "Table has been returned unaltered."
+      )
+    )
     return(x)
   }
 
-  # Rebuild the table with by = NULL to get the unstratified overall
+  # build overall table --------------------------------------------------------
+  # rebuild with `by = NULL`; the unstratified table has a single panel set
+  # (stat_0_1 .. stat_0_5) that we splice into the stratified table.
   args_overall <- utils::modifyList(x$inputs, list(by = NULL), keep.null = TRUE)
   tbl_overall <- do.call(tbl_hierarchical_incidence_rate, args_overall)
 
-  # The overall table has stat_0_1..stat_0_5 (single arm, 5 panels)
-  # Rename them to stat_0_* for consistency
-  overall_stat_cols <- grep(
-    "^stat_", names(tbl_overall$table_body),
-    value = TRUE
-  )
+  overall_stat_cols <- grep("^stat_", names(tbl_overall$table_body), value = TRUE)
 
-  # Verify row alignment
+  # check the tbls have the same structure before merging
   if (!identical(x$table_body$label, tbl_overall$table_body$label)) {
-    cli::cli_abort(
-      "Row structure mismatch between stratified and overall tables."
+    cli::cli_inform(
+      c("!" = "The structures of the original table and the overall table are not
+         identical, and the resulting table may be malformed.")
     )
   }
 
-  # Rename overall columns: stat_0_1, stat_0_2, ... stat_0_5
+  # rename overall columns to stat_0_1 .. stat_0_n
   new_col_names <- paste0("stat_0_", seq_along(overall_stat_cols))
   overall_body <- tbl_overall$table_body |>
-    dplyr::select(dplyr::all_of(overall_stat_cols))
-  names(overall_body) <- new_col_names
+    dplyr::select(dplyr::all_of(overall_stat_cols)) |>
+    stats::setNames(new_col_names)
 
-  # Bind overall columns into the main table
   x$table_body <- dplyr::bind_cols(x$table_body, overall_body)
 
-  # Copy header styling from overall table, renaming columns
+  # copy header styling for the overall columns, renaming to stat_0_*
   overall_header <- tbl_overall$table_styling$header |>
     dplyr::filter(grepl("^stat_", .data$column))
   overall_header$column <- new_col_names
-
-  # Resolve the col_label with glue (N = total denominator count)
-  total_n <- nrow(x$inputs$denominator)
-  N <- total_n
-  style_number <- gtsummary::style_number
-  resolved_label <- glue::glue(col_label)
-
-  # Set spanning header for overall columns
   overall_header$spanning_header <- NA_character_
 
-  x$table_styling$header <- dplyr::bind_rows(
-    x$table_styling$header, overall_header
-  )
+  x$table_styling$header <- dplyr::bind_rows(x$table_styling$header, overall_header)
 
-  # Add spanning header for overall columns
+  # spanning header for overall columns -- `col_label` is a glue template
+  # resolved by gtsummary against the column header context (`N`, `n`, ...).
   x <- gtsummary::modify_spanning_header(
     x,
-    tidyselect::starts_with("stat_0_") ~ resolved_label
+    tidyselect::starts_with("stat_0_") ~ col_label
   )
 
-  # Reorder columns: if last = FALSE, place overall before stratified columns
-  if (!last) {
-    x <- x |>
-      gtsummary::modify_table_body(\(body) {
-        stat_cols <- sort(grep("^stat_", names(body), value = TRUE))
-        dplyr::relocate(body, dplyr::all_of(stat_cols), .after = "label")
-      })
-  } else {
+  # reorder columns: overall first unless `last = TRUE` --------------------------
+  if (isTRUE(last)) {
     x <- x |>
       gtsummary::modify_table_body(\(body) {
         overall_cols <- grep("^stat_0_", names(body), value = TRUE)
         dplyr::relocate(body, dplyr::all_of(overall_cols), .after = dplyr::last_col())
       })
+  } else {
+    x <- x |>
+      gtsummary::modify_table_body(\(body) {
+        stat_cols <- sort(grep("^stat_", names(body), value = TRUE))
+        dplyr::relocate(body, dplyr::all_of(stat_cols), .after = "label")
+      })
   }
 
-  # Append overall inner tables so gather_ard() can recurse into them
-  x$tbls <- c(x$tbls, stats::setNames(tbl_overall$tbls, paste0("add_overall_", seq_along(tbl_overall$tbls))))
+  # correct ARD structure ------------------------------------------------------
+  # the table is a `tbl_merge` of several panels, so ARDs live in `$tbls`
+  # (no single `$cards` slot). Append the overall panels' inner tables so
+  # `gather_ard()` recurses into the overall ARDs as well.
+  x$tbls <- c(
+    x$tbls,
+    stats::setNames(
+      tbl_overall$tbls,
+      paste0("add_overall_", seq_along(tbl_overall$tbls))
+    )
+  )
 
   x$call_list <- c(x$call_list, list(add_overall = match.call()))
   x

--- a/R/tbl_hierarchical_incidence_rate.R
+++ b/R/tbl_hierarchical_incidence_rate.R
@@ -380,13 +380,22 @@ tbl_hierarchical_incidence_rate <- function(data,
   tbl_final
 }
 
+#' @param x (`tbl_hierarchical_incidence_rate`)\cr
+#'   a table created with [tbl_hierarchical_incidence_rate()].
+#' @param last (`logical(1)`)\cr
+#'   whether to place the overall column last. Default is `TRUE`.
+#' @param col_label (`string`)\cr
+#'   label for the overall column. Default is `"Overall\nN = {style_number(N)}"`.
+#' @param ... These dots are for future extensions and must be empty.
+#'
 #' @rdname tbl_hierarchical_incidence_rate
 #' @export
 add_overall.tbl_hierarchical_incidence_rate <- function(
-    x,
-    last = TRUE,
-    col_label = "Overall\nN = {style_number(N)}",
-    ...) {
+  x,
+  last = TRUE,
+  col_label = "Overall\nN = {style_number(N)}",
+  ...
+) {
   rlang::check_dots_empty()
 
   if (is.null(x$inputs[["by"]]) || length(x$inputs[["by"]]) == 0L) {
@@ -404,7 +413,8 @@ add_overall.tbl_hierarchical_incidence_rate <- function(
   # The overall table has stat_0_1..stat_0_5 (single arm, 5 panels)
   # Rename them to stat_0_* for consistency
   overall_stat_cols <- grep(
-    "^stat_", names(tbl_overall$table_body), value = TRUE
+    "^stat_", names(tbl_overall$table_body),
+    value = TRUE
   )
 
   # Verify row alignment

--- a/R/tbl_hierarchical_incidence_rate.R
+++ b/R/tbl_hierarchical_incidence_rate.R
@@ -44,6 +44,10 @@
 #' @param digits (`numeric(1)`)\cr
 #'   An integer specifying the number of decimal places to round the incidence
 #'   estimates, confidence intervals, and person-years to. Defaults to `2`.
+#' @param overall_row (`logical(1)`)\cr
+#'   Whether to include an overall summary row aggregating across all
+#'   hierarchical levels. Default is `TRUE`. The overall row label can be
+#'   customized via `label = list("..ard_hierarchical_overall.." = "Custom Label")`.
 #'
 #' @returns a gtsummary table of class `"tbl_hierarchical_incidence_rate"`.
 #' @name tbl_hierarchical_incidence_rate
@@ -86,6 +90,57 @@
 #'   )
 #' )
 #'
+#' # Custom overall row label
+#' tbl_hierarchical_incidence_rate(
+#'   data = adae,
+#'   denominator = adsl,
+#'   variables = c(AESOC, AEDECOD),
+#'   by = ARM,
+#'   start_date = TRTSDT,
+#'   end_date = TRTEDT,
+#'   event_date = AESTDTC,
+#'   label = list("..ard_hierarchical_overall.." = "Any Adverse Event")
+#' )
+#'
+#' # Without the overall row
+#' tbl_hierarchical_incidence_rate(
+#'   data = adae,
+#'   denominator = adsl,
+#'   variables = c(AESOC, AEDECOD),
+#'   by = ARM,
+#'   start_date = TRTSDT,
+#'   end_date = TRTEDT,
+#'   event_date = AESTDTC,
+#'   overall_row = FALSE
+#' )
+#'
+#' # Add an unstratified "Overall" column pooling all treatment arms
+#' tbl_hierarchical_incidence_rate(
+#'   data = adae,
+#'   denominator = adsl,
+#'   variables = c(AESOC, AEDECOD),
+#'   by = ARM,
+#'   start_date = TRTSDT,
+#'   end_date = TRTEDT,
+#'   event_date = AESTDTC
+#' ) |>
+#'   add_overall()
+#'
+#' # Customize spanning headers after table creation
+#' tbl_hierarchical_incidence_rate(
+#'   data = adae,
+#'   denominator = adsl,
+#'   variables = c(AESOC, AEDECOD),
+#'   by = ARM,
+#'   start_date = TRTSDT,
+#'   end_date = TRTEDT,
+#'   event_date = AESTDTC
+#' ) |>
+#'   gtsummary::modify_spanning_header(
+#'     tidyselect::starts_with("stat_1") ~ "Placebo (N = 3)",
+#'     tidyselect::starts_with("stat_2") ~ "Treatment (N = 2)"
+#'   )
+#'
 #' @export
 tbl_hierarchical_incidence_rate <- function(data,
                                             denominator,
@@ -101,6 +156,7 @@ tbl_hierarchical_incidence_rate <- function(data,
                                             conf.level = 0.95,
                                             conf.type = "normal",
                                             digits = 2,
+                                            overall_row = TRUE,
                                             label = NULL) {
   # 1. Base Input Validation (Missingness and standard classes)
   event_type <- rlang::arg_match(event_type)
@@ -120,6 +176,7 @@ tbl_hierarchical_incidence_rate <- function(data,
   check_string(conf.type)
   check_numeric(digits)
   check_scalar(digits)
+  check_scalar_logical(overall_row)
   if (!is.null(label) && !is.list(label)) {
     cli::cli_abort("{.arg label} must be a list or NULL.")
   }
@@ -143,15 +200,16 @@ tbl_hierarchical_incidence_rate <- function(data,
   check_scalar(end_date)
   check_scalar(event_date)
 
-  # Save inputs and call arguments
   tbl_final <- list()
-  tbl_final$call_list <- list(tbl_hierarchical_incidence_rate = match.call())
-  tbl_final$inputs <- as.list(environment())
 
-  # 4. Extract overall label BEFORE `cards` processes the dataset
-  overall_label <- "All Adverse Events"
-  if (is.list(label) && "..ard_hierarchical_overall.." %in% names(label)) {
-    overall_label <- label[["..ard_hierarchical_overall.."]]
+  # Extract overall label BEFORE `cards` processes the dataset
+
+  overall_label <- NULL
+  if (overall_row) {
+    overall_label <- "All Adverse Events"
+    if (is.list(label) && "..ard_hierarchical_overall.." %in% names(label)) {
+      overall_label <- label[["..ard_hierarchical_overall.."]]
+    }
   }
 
   # 5. Auto-extract Labels for Dataset Columns
@@ -171,28 +229,34 @@ tbl_hierarchical_incidence_rate <- function(data,
     id = dplyr::all_of(id),
     denominator = denominator,
     label = label,
-    overall_row = TRUE
+    overall_row = overall_row
   ) |>
     gtsummary::sort_hierarchical() |>
     gtsummary::modify_header(
       gtsummary::all_stat_cols() ~ "No. of\nParticipants\nwith AE (%)"
-    ) |>
-    gtsummary::modify_table_body(~ .x |> dplyr::mutate(
-      label = dplyr::if_else(
-        dplyr::row_number() == 1, .env$overall_label, .data$label
-      )
-    ))
-
-  # 6. Generate ARDs cleanly using explicit piping
-  ard_overall <- .prep_incidence_rate_data(
-    data, denominator, id, by, start_date,
-    end_date, event_date, event_type, NULL
-  ) |>
-    .compute_incidence_rate_ard(
-      by, NULL, digits,
-      n_person_time = n_person_time, unit_label = unit_label,
-      conf.level = conf.level, conf.type = conf.type
     )
+
+  if (overall_row) {
+    tbl_base <- tbl_base |>
+      gtsummary::modify_table_body(~ .x |> dplyr::mutate(
+        label = dplyr::if_else(
+          dplyr::row_number() == 1, .env$overall_label, .data$label
+        )
+      ))
+  }
+
+  # Generate ARDs cleanly using explicit piping
+  if (overall_row) {
+    ard_overall <- .prep_incidence_rate_data(
+      data, denominator, id, by, start_date,
+      end_date, event_date, event_type, NULL
+    ) |>
+      .compute_incidence_rate_ard(
+        by, NULL, digits,
+        n_person_time = n_person_time, unit_label = unit_label,
+        conf.level = conf.level, conf.type = conf.type
+      )
+  }
 
   ard_lvl1 <- .prep_incidence_rate_data(
     data, denominator, id, by, start_date,
@@ -245,29 +309,37 @@ tbl_hierarchical_incidence_rate <- function(data,
   )
 
   tbls_rates <- lapply(names(tbl_stat_labels), function(stat) {
-    list(
-      gtsummary::tbl_ard_summary(
+    tbl_hier <- gtsummary::tbl_ard_hierarchical(
+      cards = ard_hierarchical_combined,
+      by = dplyr::all_of(by),
+      variables = dplyr::all_of(variables),
+      statistic = ~stat
+    )
+
+    if (overall_row) {
+      tbl_overall_stat <- gtsummary::tbl_ard_summary(
         ard_overall,
         by = dplyr::all_of(by), statistic = ~stat
       ) |>
         gtsummary::modify_table_body(~ .x |> dplyr::mutate(
           row_type = "level", var_label = NA, label = .env$overall_label,
           group1 = "..ard_hierarchical_overall.."
-        )),
+        ))
 
-      # use combined ard in the function call
-      gtsummary::tbl_ard_hierarchical(
-        cards = ard_hierarchical_combined,
-        by = dplyr::all_of(by),
-        variables = dplyr::all_of(variables),
-        statistic = ~stat
-      )
-    ) |>
-      gtsummary::tbl_stack(attr_order = 2:1, quiet = TRUE) |>
+      tbl_hier <- list(tbl_overall_stat, tbl_hier) |>
+        gtsummary::tbl_stack(attr_order = 2:1, quiet = TRUE)
+    }
+
+    tbl_hier |>
       gtsummary::modify_header(
         gtsummary::all_stat_cols() ~ tbl_stat_labels[[stat]]
       )
   })
+
+  # Extract arm-to-column mapping before merge for spanning headers
+  arm_header_map <- tbl_base$table_styling$header |>
+    dplyr::filter(grepl("^stat_", .data$column)) |>
+    dplyr::select("column", "label", "modify_stat_level", "modify_stat_n")
 
   tbl_final <- c(list(tbl_base), tbls_rates) |>
     gtsummary::tbl_merge(tab_spanner = FALSE) |>
@@ -277,9 +349,124 @@ tbl_hierarchical_incidence_rate <- function(data,
     }) |>
     gtsummary::remove_footnote_header(tidyselect::everything())
 
+  # Apply spanning headers from the arm mapping (e.g., stat_1_* -> "Placebo\nN = 3")
+  if (!is.null(by) && nrow(arm_header_map) > 0L) {
+    spanning_formulas <- lapply(seq_len(nrow(arm_header_map)), function(i) {
+      arm_idx <- sub("^stat_", "", arm_header_map$column[i])
+      arm_level <- arm_header_map$modify_stat_level[i]
+      arm_n <- arm_header_map$modify_stat_n[i]
+      prefix <- paste0("stat_", arm_idx, "_")
+      spanner_label <- paste0(arm_level, "\nN = ", arm_n)
+      rlang::new_formula(
+        lhs = rlang::expr(tidyselect::starts_with(!!prefix)),
+        rhs = rlang::expr(!!spanner_label)
+      )
+    })
+
+    tbl_final <- rlang::inject(
+      gtsummary::modify_spanning_header(tbl_final, !!!spanning_formulas)
+    )
+  }
+
+  # Store inputs for add_overall() reconstruction
+  tbl_final$inputs <- mget(
+    names(formals(tbl_hierarchical_incidence_rate)),
+    envir = environment()
+  )
+  tbl_final$call_list <- list(tbl_hierarchical_incidence_rate = match.call())
+
   class(tbl_final) <- c("tbl_hierarchical_incidence_rate", class(tbl_final))
 
   tbl_final
+}
+
+#' @rdname tbl_hierarchical_incidence_rate
+#' @export
+add_overall.tbl_hierarchical_incidence_rate <- function(
+    x,
+    last = TRUE,
+    col_label = "Overall\nN = {style_number(N)}",
+    ...) {
+  rlang::check_dots_empty()
+
+  if (is.null(x$inputs[["by"]]) || length(x$inputs[["by"]]) == 0L) {
+    cli::cli_inform(c(
+      "Cannot add an overall column when the table has no {.arg by} variable.",
+      i = "Returning table unaltered."
+    ))
+    return(x)
+  }
+
+  # Rebuild the table with by = NULL to get the unstratified overall
+  args_overall <- utils::modifyList(x$inputs, list(by = NULL), keep.null = TRUE)
+  tbl_overall <- do.call(tbl_hierarchical_incidence_rate, args_overall)
+
+  # The overall table has stat_0_1..stat_0_5 (single arm, 5 panels)
+  # Rename them to stat_0_* for consistency
+  overall_stat_cols <- grep(
+    "^stat_", names(tbl_overall$table_body), value = TRUE
+  )
+
+  # Verify row alignment
+  if (!identical(x$table_body$label, tbl_overall$table_body$label)) {
+    cli::cli_abort(
+      "Row structure mismatch between stratified and overall tables."
+    )
+  }
+
+  # Rename overall columns: stat_0_1, stat_0_2, ... stat_0_5
+  new_col_names <- paste0("stat_0_", seq_along(overall_stat_cols))
+  overall_body <- tbl_overall$table_body |>
+    dplyr::select(dplyr::all_of(overall_stat_cols))
+  names(overall_body) <- new_col_names
+
+  # Bind overall columns into the main table
+  x$table_body <- dplyr::bind_cols(x$table_body, overall_body)
+
+  # Copy header styling from overall table, renaming columns
+  overall_header <- tbl_overall$table_styling$header |>
+    dplyr::filter(grepl("^stat_", .data$column))
+  overall_header$column <- new_col_names
+
+  # Resolve the col_label with glue (N = total denominator count)
+  total_n <- nrow(x$inputs$denominator)
+  N <- total_n
+  style_number <- gtsummary::style_number
+  resolved_label <- glue::glue(col_label)
+
+  # Set spanning header for overall columns
+  overall_header$spanning_header <- NA_character_
+
+  x$table_styling$header <- dplyr::bind_rows(
+    x$table_styling$header, overall_header
+  )
+
+  # Add spanning header for overall columns
+  x <- gtsummary::modify_spanning_header(
+    x,
+    tidyselect::starts_with("stat_0_") ~ resolved_label
+  )
+
+  # Reorder columns: if last = FALSE, place overall before stratified columns
+  if (!last) {
+    x <- x |>
+      gtsummary::modify_table_body(\(body) {
+        stat_cols <- sort(grep("^stat_", names(body), value = TRUE))
+        dplyr::relocate(body, dplyr::all_of(stat_cols), .after = "label")
+      })
+  } else {
+    x <- x |>
+      gtsummary::modify_table_body(\(body) {
+        overall_cols <- grep("^stat_0_", names(body), value = TRUE)
+        dplyr::relocate(body, dplyr::all_of(overall_cols), .after = dplyr::last_col())
+      })
+  }
+
+  # Append overall inner tables so gather_ard() can recurse into them
+  x$tbls <- c(x$tbls, stats::setNames(tbl_overall$tbls, paste0("add_overall_", seq_along(tbl_overall$tbls))))
+
+  x$call_list <- c(x$call_list, list(add_overall = match.call()))
+  x
 }
 
 # ==============================================================================

--- a/man/tbl_hierarchical_incidence_rate.Rd
+++ b/man/tbl_hierarchical_incidence_rate.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/tbl_hierarchical_incidence_rate.R
 \name{tbl_hierarchical_incidence_rate}
 \alias{tbl_hierarchical_incidence_rate}
+\alias{add_overall.tbl_hierarchical_incidence_rate}
 \title{Hierarchical Exposure-Adjusted Incidence Rates}
 \usage{
 tbl_hierarchical_incidence_rate(
@@ -23,12 +24,7 @@ tbl_hierarchical_incidence_rate(
   label = NULL
 )
 
-\method{add_overall}{tbl_hierarchical_incidence_rate}(
-  x,
-  last = TRUE,
-  col_label = "Overall\nN = {style_number(N)}",
-  ...
-)
+\method{add_overall}{tbl_hierarchical_incidence_rate}(x, last = TRUE, col_label = "Overall\\nN = {style_number(N)}", ...)
 }
 \arguments{
 \item{data}{(\code{data.frame})\cr
@@ -96,6 +92,17 @@ customized via \code{label = list("..ard_hierarchical_overall.." = "Custom Label
 used to override default labels in hierarchical table, e.g. \code{list(AESOC = "System Organ Class")}.
 The default for each variable is the column label attribute, \code{attr(., 'label')}.
 If no label has been set, the column name is used.}
+
+\item{x}{(\code{tbl_hierarchical_incidence_rate})\cr
+a table created with \code{\link[=tbl_hierarchical_incidence_rate]{tbl_hierarchical_incidence_rate()}}.}
+
+\item{last}{(\code{logical(1)})\cr
+whether to place the overall column last. Default is \code{TRUE}.}
+
+\item{col_label}{(\code{string})\cr
+label for the overall column. Default is \code{"Overall\\nN = {style_number(N)}"}.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 a gtsummary table of class \code{"tbl_hierarchical_incidence_rate"}.

--- a/man/tbl_hierarchical_incidence_rate.Rd
+++ b/man/tbl_hierarchical_incidence_rate.Rd
@@ -21,10 +21,16 @@ tbl_hierarchical_incidence_rate(
   conf.type = "normal",
   digits = 2,
   overall_row = TRUE,
+  spanning_label = "{level}  \\n(N = {n})",
   label = NULL
 )
 
-\method{add_overall}{tbl_hierarchical_incidence_rate}(x, last = TRUE, col_label = "Overall\\nN = {style_number(N)}", ...)
+\method{add_overall}{tbl_hierarchical_incidence_rate}(
+  x,
+  last = FALSE,
+  col_label = "All Participants  \\n(N = {style_roche_number(N)})",
+  ...
+)
 }
 \arguments{
 \item{data}{(\code{data.frame})\cr
@@ -88,19 +94,28 @@ Whether to include an overall summary row aggregating across all
 hierarchical levels. Default is \code{TRUE}. The overall row label can be
 customized via \code{label = list("..ard_hierarchical_overall.." = "Custom Label")}.}
 
+\item{spanning_label}{(\code{string})\cr
+A \link[glue:glue]{glue}-style template for the per-arm spanning headers when
+\code{by} is supplied. Available substitutions are \code{{level}} (the arm level) and
+\code{{n}} (the arm participant count). Default is \code{"{level}  \\\\n(N = {n})"},
+matching the column-header convention used elsewhere in the package.}
+
 \item{label}{(\code{\link[gtsummary:syntax]{formula-list-selector}})\cr
 used to override default labels in hierarchical table, e.g. \code{list(AESOC = "System Organ Class")}.
 The default for each variable is the column label attribute, \code{attr(., 'label')}.
 If no label has been set, the column name is used.}
 
 \item{x}{(\code{tbl_hierarchical_incidence_rate})\cr
-a table created with \code{\link[=tbl_hierarchical_incidence_rate]{tbl_hierarchical_incidence_rate()}}.}
+A table created with \code{\link[=tbl_hierarchical_incidence_rate]{tbl_hierarchical_incidence_rate()}}.}
 
 \item{last}{(\code{logical(1)})\cr
-whether to place the overall column last. Default is \code{TRUE}.}
+When \code{add_overall()} is used, whether to place the overall columns after
+(\code{TRUE}) or before (\code{FALSE}) the stratified columns. Default is \code{FALSE}.}
 
 \item{col_label}{(\code{string})\cr
-label for the overall column. Default is \code{"Overall\\nN = {style_number(N)}"}.}
+A \link[glue:glue]{glue}-style template for the overall spanning header added by
+\code{add_overall()}. Resolved against the column header context (e.g. \code{{N}},
+\code{{n}}). Default is \code{"All Participants  \\\\n(N = {style_roche_number(N)})"}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 }
@@ -191,7 +206,7 @@ tbl_hierarchical_incidence_rate(
 ) |>
   add_overall()
 
-# Customize spanning headers after table creation
+# Customize the per-arm spanning headers with a glue template
 tbl_hierarchical_incidence_rate(
   data = adae,
   denominator = adsl,
@@ -199,11 +214,8 @@ tbl_hierarchical_incidence_rate(
   by = ARM,
   start_date = TRTSDT,
   end_date = TRTEDT,
-  event_date = AESTDTC
-) |>
-  gtsummary::modify_spanning_header(
-    tidyselect::starts_with("stat_1") ~ "Placebo (N = 3)",
-    tidyselect::starts_with("stat_2") ~ "Treatment (N = 2)"
-  )
+  event_date = AESTDTC,
+  spanning_label = "{level} (N = {n})"
+)
 
 }

--- a/man/tbl_hierarchical_incidence_rate.Rd
+++ b/man/tbl_hierarchical_incidence_rate.Rd
@@ -19,7 +19,15 @@ tbl_hierarchical_incidence_rate(
   conf.level = 0.95,
   conf.type = "normal",
   digits = 2,
+  overall_row = TRUE,
   label = NULL
+)
+
+\method{add_overall}{tbl_hierarchical_incidence_rate}(
+  x,
+  last = TRUE,
+  col_label = "Overall\nN = {style_number(N)}",
+  ...
 )
 }
 \arguments{
@@ -79,6 +87,11 @@ Confidence interval type. Default is \code{"normal"}. Passed directly to
 An integer specifying the number of decimal places to round the incidence
 estimates, confidence intervals, and person-years to. Defaults to \code{2}.}
 
+\item{overall_row}{(\code{logical(1)})\cr
+Whether to include an overall summary row aggregating across all
+hierarchical levels. Default is \code{TRUE}. The overall row label can be
+customized via \code{label = list("..ard_hierarchical_overall.." = "Custom Label")}.}
+
 \item{label}{(\code{\link[gtsummary:syntax]{formula-list-selector}})\cr
 used to override default labels in hierarchical table, e.g. \code{list(AESOC = "System Organ Class")}.
 The default for each variable is the column label attribute, \code{attr(., 'label')}.
@@ -134,5 +147,56 @@ tbl_hierarchical_incidence_rate(
     "..ard_hierarchical_overall.." = "All Adverse Events"
   )
 )
+
+# Custom overall row label
+tbl_hierarchical_incidence_rate(
+  data = adae,
+  denominator = adsl,
+  variables = c(AESOC, AEDECOD),
+  by = ARM,
+  start_date = TRTSDT,
+  end_date = TRTEDT,
+  event_date = AESTDTC,
+  label = list("..ard_hierarchical_overall.." = "Any Adverse Event")
+)
+
+# Without the overall row
+tbl_hierarchical_incidence_rate(
+  data = adae,
+  denominator = adsl,
+  variables = c(AESOC, AEDECOD),
+  by = ARM,
+  start_date = TRTSDT,
+  end_date = TRTEDT,
+  event_date = AESTDTC,
+  overall_row = FALSE
+)
+
+# Add an unstratified "Overall" column pooling all treatment arms
+tbl_hierarchical_incidence_rate(
+  data = adae,
+  denominator = adsl,
+  variables = c(AESOC, AEDECOD),
+  by = ARM,
+  start_date = TRTSDT,
+  end_date = TRTEDT,
+  event_date = AESTDTC
+) |>
+  add_overall()
+
+# Customize spanning headers after table creation
+tbl_hierarchical_incidence_rate(
+  data = adae,
+  denominator = adsl,
+  variables = c(AESOC, AEDECOD),
+  by = ARM,
+  start_date = TRTSDT,
+  end_date = TRTEDT,
+  event_date = AESTDTC
+) |>
+  gtsummary::modify_spanning_header(
+    tidyselect::starts_with("stat_1") ~ "Placebo (N = 3)",
+    tidyselect::starts_with("stat_2") ~ "Treatment (N = 2)"
+  )
 
 }

--- a/tests/testthat/test-tbl_hierarchical_incidence_rate.R
+++ b/tests/testthat/test-tbl_hierarchical_incidence_rate.R
@@ -259,6 +259,27 @@ test_that("spanning headers are applied for treatment arms", {
   # each arm should appear in the spanning headers
   expect_true(any(grepl("Pbo", spanners$spanning_header)))
   expect_true(any(grepl("Trt", spanners$spanning_header)))
+
+  # default uses the package convention "{level}  \n(N = {n})"
+  expect_true(any(grepl("\\(N = [0-9]+\\)", spanners$spanning_header)))
+})
+
+test_that("spanning_label glue template customizes treatment arm headers", {
+  tbl <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = ARM,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC,
+    spanning_label = "{level} / n={n}"
+  )
+
+  spanners <- tbl$table_styling$spanning_header
+  # custom format should appear instead of the default parenthesized form
+  expect_true(any(grepl("/ n=[0-9]+", spanners$spanning_header)))
+  expect_false(any(grepl("\\(N = [0-9]+\\)", spanners$spanning_header)))
 })
 
 test_that("add_overall appends overall columns", {
@@ -286,9 +307,26 @@ test_that("add_overall appends overall columns", {
   # overall columns should exist
   expect_true(any(grepl("^stat_0_", names(tbl_overall$table_body))))
 
-  # spanning header should contain "Overall"
+  # spanning header should contain the default overall label
   spanners <- tbl_overall$table_styling$spanning_header
-  expect_true(any(grepl("Overall", spanners$spanning_header)))
+  expect_true(any(grepl("All Participants", spanners$spanning_header)))
+})
+
+test_that("add_overall accepts a custom col_label", {
+  tbl <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = ARM,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC
+  )
+
+  tbl_overall <- tbl |> add_overall(col_label = "Overall (N = {N})")
+
+  spanners <- tbl_overall$table_styling$spanning_header
+  expect_true(any(grepl("Overall \\(N = ", spanners$spanning_header)))
 })
 
 test_that("add_overall with last = TRUE places overall columns at the end", {
@@ -327,7 +365,7 @@ test_that("add_overall on table without by returns unaltered", {
 
   expect_message(
     tbl_result <- tbl_no_by |> add_overall(),
-    "Cannot add an overall column"
+    "Original table was not stratified"
   )
 
   # table should be unchanged

--- a/tests/testthat/test-tbl_hierarchical_incidence_rate.R
+++ b/tests/testthat/test-tbl_hierarchical_incidence_rate.R
@@ -206,3 +206,154 @@ test_that("tbl_hierarchical_incidence_rate fails safely on bad inputs", {
     )
   )
 })
+
+test_that("overall_row = FALSE omits the overall summary row", {
+  tbl_with <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = ARM,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC,
+    overall_row = TRUE
+  )
+
+  tbl_without <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = ARM,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC,
+    overall_row = FALSE
+  )
+
+  # table without overall row should have fewer rows
+  expect_lt(
+    nrow(tbl_without$table_body),
+    nrow(tbl_with$table_body)
+  )
+
+  # "All Adverse Events" label should not appear
+  expect_false(
+    "All Adverse Events" %in% tbl_without$table_body$label
+  )
+})
+
+test_that("spanning headers are applied for treatment arms", {
+  tbl <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = ARM,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC
+  )
+
+  spanners <- tbl$table_styling$spanning_header
+  expect_gt(nrow(spanners), 0L)
+
+  # each arm should appear in the spanning headers
+  expect_true(any(grepl("Pbo", spanners$spanning_header)))
+  expect_true(any(grepl("Trt", spanners$spanning_header)))
+})
+
+test_that("add_overall appends overall columns", {
+  tbl <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = ARM,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC
+  )
+
+  n_cols_before <- length(grep("^stat_", names(tbl$table_body)))
+
+  expect_no_error(
+    tbl_overall <- tbl |> add_overall()
+  )
+
+  n_cols_after <- length(grep("^stat_", names(tbl_overall$table_body)))
+
+  # add_overall should add 5 new stat columns (count + 4 rate stats)
+  expect_equal(n_cols_after, n_cols_before + 5L)
+
+  # overall columns should exist
+  expect_true(any(grepl("^stat_0_", names(tbl_overall$table_body))))
+
+  # spanning header should contain "Overall"
+  spanners <- tbl_overall$table_styling$spanning_header
+  expect_true(any(grepl("Overall", spanners$spanning_header)))
+})
+
+test_that("add_overall with last = TRUE places overall columns at the end", {
+  tbl <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = ARM,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC
+  )
+
+  expect_no_error(
+    tbl_last <- tbl |> add_overall(last = TRUE)
+  )
+
+  stat_cols <- grep("^stat_", names(tbl_last$table_body), value = TRUE)
+  overall_cols <- grep("^stat_0_", stat_cols, value = TRUE)
+
+  # overall columns should be at the end
+  overall_positions <- match(overall_cols, stat_cols)
+  expect_true(all(overall_positions > (length(stat_cols) - length(overall_cols))))
+})
+
+test_that("add_overall on table without by returns unaltered", {
+  tbl_no_by <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = NULL,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC
+  )
+
+  expect_message(
+    tbl_result <- tbl_no_by |> add_overall(),
+    "Cannot add an overall column"
+  )
+
+  # table should be unchanged
+  expect_equal(
+    names(tbl_result$table_body),
+    names(tbl_no_by$table_body)
+  )
+})
+
+test_that("gather_ard works after add_overall", {
+  tbl <- tbl_hierarchical_incidence_rate(
+    data = adae_test,
+    denominator = adsl_test,
+    variables = c(AESOC, AEDECOD),
+    by = ARM,
+    start_date = TRTSDT,
+    end_date = TRTEDT,
+    event_date = AESTDTC
+  )
+
+  ard_before <- gtsummary::gather_ard(tbl)
+  n_before <- length(ard_before)
+
+  tbl_with_overall <- tbl |> add_overall()
+  ard_after <- gtsummary::gather_ard(tbl_with_overall)
+
+  # gather_ard should return more elements after add_overall
+  expect_gt(length(ard_after), n_before)
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `tbl_hierarchical_incidence_rate()` gains an `overall_row` argument to control whether the overall summary row is included. (#264, @Melkiades)
* `tbl_hierarchical_incidence_rate()` now supports `add_overall()` to append an unstratified "Overall" column pooling all treatment arms. (#264, @Melkiades)
* `tbl_hierarchical_incidence_rate()` now renders spanning headers for treatment arm columns. (#264, @Melkiades)

The `add_overall()` method rebuilds the entire table with `by = NULL` and merges the resulting 5 panels (count, n_events, PY, rate, CI) as `stat_0_*` columns into the existing table. Spanning headers use `tidyselect::starts_with()` formulas to group columns by arm.

**Reference GitHub issue associated with pull request.** closes #264

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer