### PR TITLE
[SUPERSEDED by #274] Remove vertical header frame in theme_gtsummary_roche

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # crane 0.3.3.9001
 
+* `theme_gtsummary_roche()` no longer draws a vertical frame around the flextable header; only horizontal rules are kept. This removes the box around the title/study/parameter block and the inconsistent missing right border. (#272)
+
 * Fixed minor typo in the DESCRIPTION file.
 
 * `tbl_hierarchical_incidence_rate()` gains an `overall_row` argument to control whether the overall summary row is included. (#264)

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -96,7 +96,12 @@ theme_gtsummary_roche <- function(font_size = NULL,
         ),
         valign = list( # valign only because it will append to to last commands
           rlang::expr(flextable::fontsize(size = !!((font_size %||% 8) - 1), part = "footer")), # second fontsize spectbl
-          rlang::expr(flextable::border_outer(part = "header", border = !!border)), # second command from border
+          # Horizontal rules only on the header: a top and bottom rule plus the
+          # inner horizontal rules between header rows. Avoid border_outer() here
+          # so no vertical frame is drawn around the title/study/parameter block
+          # (which also left an inconsistent missing right border).
+          rlang::expr(flextable::hline_top(part = "header", border = !!border)),
+          rlang::expr(flextable::hline_bottom(part = "header", border = !!border)),
           rlang::expr(flextable::border_inner_h(part = "header", border = !!border)), # fix different line sizes
           rlang::expr(flextable::valign(valign = "top", part = "all")),
           rlang::expr(flextable::font(fontname = "Arial", part = "all")),

--- a/tests/testthat/_snaps/theme_gtsummary_roche.md
+++ b/tests/testthat/_snaps/theme_gtsummary_roche.md
@@ -26,29 +26,33 @@
       flextable::fontsize(size = 7, part = "footer")
       
       $user_added3[[2]]
-      flextable::border_outer(part = "header", border = list(width = 0.5, 
+      flextable::hline_top(part = "header", border = list(width = 0.5, 
           color = "#666666", style = "solid"))
       
       $user_added3[[3]]
-      flextable::border_inner_h(part = "header", border = list(width = 0.5, 
+      flextable::hline_bottom(part = "header", border = list(width = 0.5, 
           color = "#666666", style = "solid"))
       
       $user_added3[[4]]
-      flextable::valign(valign = "top", part = "all")
+      flextable::border_inner_h(part = "header", border = list(width = 0.5, 
+          color = "#666666", style = "solid"))
       
       $user_added3[[5]]
-      flextable::font(fontname = "Arial", part = "all")
+      flextable::valign(valign = "top", part = "all")
       
       $user_added3[[6]]
-      flextable::padding(padding.top = 0, part = "all")
+      flextable::font(fontname = "Arial", part = "all")
       
       $user_added3[[7]]
-      flextable::padding(padding.bottom = 0, part = "all")
+      flextable::padding(padding.top = 0, part = "all")
       
       $user_added3[[8]]
-      flextable::line_spacing(space = 1, part = "all")
+      flextable::padding(padding.bottom = 0, part = "all")
       
       $user_added3[[9]]
+      flextable::line_spacing(space = 1, part = "all")
+      
+      $user_added3[[10]]
       flextable::set_table_properties(layout = "autofit")
       
       


### PR DESCRIPTION
Superseded by #274 (corrected authorship and review fixes). This PR is closed and its branch deleted; no action needed here.