### PR TITLE
Frame flextable header column labels with an outer border only

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
     labelled,
     magick,
     mmrm,
+    officer,
     parameters,
     pharmaverseadam,
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,7 @@ Suggests:
     testthat (>= 3.0.0),
     tidyselect,
     withr (>= 3.0.1),
+    xml2,
     yaml
 Config/Needs/check: hms
 Config/Needs/website: rmarkdown, yaml

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # crane 0.3.3.9001
 
-* `theme_gtsummary_roche()` no longer draws a vertical frame around the flextable header; only horizontal rules are kept. This removes the box around the title/study/parameter block and the inconsistent missing right border. (#272)
+* `theme_gtsummary_roche()` now frames the flextable column labels with an outer border only, removing the internal borders between header rows and the inconsistent missing right border. (#272)
 
 * Fixed minor typo in the DESCRIPTION file.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # crane 0.3.3.9001
 
+* `theme_gtsummary_roche()` no longer draws a vertical frame around the flextable header; only horizontal rules are kept. This removes the box around the title/study/parameter block and the inconsistent missing right border. (#272)
+
 * Fixed minor typo in the DESCRIPTION file.
 
 * `tbl_hierarchical_incidence_rate()` gains an `overall_row` argument to control whether the overall summary row is included. (#264)

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -96,7 +96,12 @@ theme_gtsummary_roche <- function(font_size = NULL,
         ),
         valign = list( # valign only because it will append to to last commands
           rlang::expr(flextable::fontsize(size = !!((font_size %||% 8) - 1), part = "footer")), # second fontsize spectbl
-          rlang::expr(flextable::border_outer(part = "header", border = !!border)), # second command from border
+          # Horizontal rules only on the header: a top and bottom rule plus the
+          # inner horizontal rules between header rows. Avoid border_outer() here
+          # so no vertical frame is drawn around the title/study/parameter block
+          # (which also left an inconsistent missing right border).
+          rlang::expr(flextable::hline_top(part = "header", border = !!border)),
+          rlang::expr(flextable::hline_bottom(part = "header", border = !!border)),
           rlang::expr(flextable::border_inner_h(part = "header", border = !!border)), # fix different line sizes
           rlang::expr(flextable::valign(valign = "top", part = "all")),
           rlang::expr(flextable::font(fontname = "Arial", part = "all")),

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -96,11 +96,11 @@ theme_gtsummary_roche <- function(font_size = NULL,
         ),
         valign = list( # valign only because it will append to to last commands
           rlang::expr(flextable::fontsize(size = !!((font_size %||% 8) - 1), part = "footer")), # second fontsize spectbl
-          # Column labels get an outer border only: clear any internal borders
-          # between header rows, then frame the block with a single outer box.
+          # outer box only. style = "none" (not width = 0) so docx doesn't draw
+          # a line between a spanner and the column labels.
           rlang::expr(flextable::border_inner_h(
             part = "header",
-            border = flextable::fp_border_default(width = 0)
+            border = officer::fp_border(width = 0, style = "none")
           )),
           rlang::expr(flextable::border_outer(part = "header", border = !!border)),
           rlang::expr(flextable::valign(valign = "top", part = "all")),

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -96,13 +96,13 @@ theme_gtsummary_roche <- function(font_size = NULL,
         ),
         valign = list( # valign only because it will append to to last commands
           rlang::expr(flextable::fontsize(size = !!((font_size %||% 8) - 1), part = "footer")), # second fontsize spectbl
-          # Horizontal rules only on the header: a top and bottom rule plus the
-          # inner horizontal rules between header rows. Avoid border_outer() here
-          # so no vertical frame is drawn around the title/study/parameter block
-          # (which also left an inconsistent missing right border).
-          rlang::expr(flextable::hline_top(part = "header", border = !!border)),
-          rlang::expr(flextable::hline_bottom(part = "header", border = !!border)),
-          rlang::expr(flextable::border_inner_h(part = "header", border = !!border)), # fix different line sizes
+          # Column labels get an outer border only: clear any internal borders
+          # between header rows, then frame the block with a single outer box.
+          rlang::expr(flextable::border_inner_h(
+            part = "header",
+            border = flextable::fp_border_default(width = 0)
+          )),
+          rlang::expr(flextable::border_outer(part = "header", border = !!border)),
           rlang::expr(flextable::valign(valign = "top", part = "all")),
           rlang::expr(flextable::font(fontname = "Arial", part = "all")),
           rlang::expr(flextable::padding(padding.top = 0, part = "all")),

--- a/tests/testthat/_snaps/theme_gtsummary_roche.md
+++ b/tests/testthat/_snaps/theme_gtsummary_roche.md
@@ -26,33 +26,28 @@
       flextable::fontsize(size = 7, part = "footer")
       
       $user_added3[[2]]
-      flextable::hline_top(part = "header", border = list(width = 0.5, 
-          color = "#666666", style = "solid"))
+      flextable::border_inner_h(part = "header", border = flextable::fp_border_default(width = 0))
       
       $user_added3[[3]]
-      flextable::hline_bottom(part = "header", border = list(width = 0.5, 
+      flextable::border_outer(part = "header", border = list(width = 0.5, 
           color = "#666666", style = "solid"))
       
       $user_added3[[4]]
-      flextable::border_inner_h(part = "header", border = list(width = 0.5, 
-          color = "#666666", style = "solid"))
-      
-      $user_added3[[5]]
       flextable::valign(valign = "top", part = "all")
       
-      $user_added3[[6]]
+      $user_added3[[5]]
       flextable::font(fontname = "Arial", part = "all")
       
-      $user_added3[[7]]
+      $user_added3[[6]]
       flextable::padding(padding.top = 0, part = "all")
       
-      $user_added3[[8]]
+      $user_added3[[7]]
       flextable::padding(padding.bottom = 0, part = "all")
       
-      $user_added3[[9]]
+      $user_added3[[8]]
       flextable::line_spacing(space = 1, part = "all")
       
-      $user_added3[[10]]
+      $user_added3[[9]]
       flextable::set_table_properties(layout = "autofit")
       
       

--- a/tests/testthat/_snaps/theme_gtsummary_roche.md
+++ b/tests/testthat/_snaps/theme_gtsummary_roche.md
@@ -26,7 +26,8 @@
       flextable::fontsize(size = 7, part = "footer")
       
       $user_added3[[2]]
-      flextable::border_inner_h(part = "header", border = flextable::fp_border_default(width = 0))
+      flextable::border_inner_h(part = "header", border = officer::fp_border(width = 0, 
+          style = "none"))
       
       $user_added3[[3]]
       flextable::border_outer(part = "header", border = list(width = 0.5, 
@@ -51,4 +52,3 @@
       flextable::set_table_properties(layout = "autofit")
       
       
-

--- a/tests/testthat/_snaps/theme_gtsummary_roche.md
+++ b/tests/testthat/_snaps/theme_gtsummary_roche.md
@@ -26,29 +26,33 @@
       flextable::fontsize(size = 7, part = "footer")
       
       $user_added3[[2]]
-      flextable::border_outer(part = "header", border = list(width = 0.5, 
+      flextable::hline_top(part = "header", border = list(width = 0.5, 
           color = "#666666", style = "solid"))
       
       $user_added3[[3]]
-      flextable::border_inner_h(part = "header", border = list(width = 0.5, 
+      flextable::hline_bottom(part = "header", border = list(width = 0.5, 
           color = "#666666", style = "solid"))
       
       $user_added3[[4]]
-      flextable::valign(valign = "top", part = "all")
+      flextable::border_inner_h(part = "header", border = list(width = 0.5, 
+          color = "#666666", style = "solid"))
       
       $user_added3[[5]]
-      flextable::font(fontname = "Arial", part = "all")
+      flextable::valign(valign = "top", part = "all")
       
       $user_added3[[6]]
-      flextable::padding(padding.top = 0, part = "all")
+      flextable::font(fontname = "Arial", part = "all")
       
       $user_added3[[7]]
-      flextable::padding(padding.bottom = 0, part = "all")
+      flextable::padding(padding.top = 0, part = "all")
       
       $user_added3[[8]]
-      flextable::line_spacing(space = 1, part = "all")
+      flextable::padding(padding.bottom = 0, part = "all")
       
       $user_added3[[9]]
+      flextable::line_spacing(space = 1, part = "all")
+      
+      $user_added3[[10]]
       flextable::set_table_properties(layout = "autofit")
       
       

--- a/tests/testthat/test-theme_gtsummary_roche.R
+++ b/tests/testthat/test-theme_gtsummary_roche.R
@@ -128,7 +128,51 @@ test_that("theme pre-conversion modifies header not to be bold and border only 0
   expect_true(all(bottom[n_hdr, ] == 0.5)) # bottom of the block
   if (n_hdr > 1) {
     expect_true(all(bottom[-n_hdr, ] == 0)) # no internal horizontal borders
+    # The internal border must also be style "none": a width-0 solid border is
+    # still written as a visible single line in docx (regression with spanners).
+    style_bottom <- tbl$header$styles$cells$border.style.bottom$data
+    expect_true(all(style_bottom[-n_hdr, ] == "none"))
   }
+})
+
+test_that("theme draws no internal horizontal line between spanner and column labels in docx", {
+  skip_if_not_installed("officer")
+  skip_if_not_installed("flextable")
+
+  tbl <- with_gtsummary_theme(
+    x = theme_gtsummary_roche(),
+    {
+      t1 <- gtsummary::trial |> gtsummary::tbl_summary(by = trt, include = age)
+      t2 <- gtsummary::trial |> gtsummary::tbl_summary(by = trt, include = grade)
+      gtsummary::tbl_merge(
+        list(t1, t2),
+        tab_spanner = c("**Group A**", "**Group B**")
+      ) |>
+        gtsummary::as_flex_table()
+    }
+  )
+
+  f <- withr::local_tempfile(fileext = ".docx")
+  flextable::save_as_docx(tbl, path = f)
+  d <- withr::local_tempdir()
+  utils::unzip(f, exdir = d)
+  xml <- paste(readLines(file.path(d, "word", "document.xml"), warn = FALSE), collapse = "")
+  rows <- regmatches(xml, gregexpr("<w:tr\\b.*?</w:tr>", xml))[[1]]
+
+  spanner <- rows[grepl("Group A", rows)][1]
+  labels <- rows[grepl("Characteristic", rows)][1]
+
+  border_val <- function(row, side) {
+    m <- regmatches(row, regexpr(sprintf('<w:%s w:val="[a-z]+"', side), row))
+    if (length(m)) sub('.*w:val="([a-z]+)".*', "\\1", m) else NA_character_
+  }
+
+  # No line between the spanner row and the column-label row.
+  expect_identical(border_val(spanner, "bottom"), "none")
+  expect_identical(border_val(labels, "top"), "none")
+  # Outer frame of the header block is kept.
+  expect_identical(border_val(spanner, "top"), "single")
+  expect_identical(border_val(labels, "bottom"), "single")
 })
 
 test_that("theme pre-conversion protects stat columns with non-breaking spaces", {

--- a/tests/testthat/test-theme_gtsummary_roche.R
+++ b/tests/testthat/test-theme_gtsummary_roche.R
@@ -138,6 +138,9 @@ test_that("theme pre-conversion modifies header not to be bold and border only 0
 test_that("theme draws no internal horizontal line between spanner and column labels in docx", {
   skip_if_not_installed("officer")
   skip_if_not_installed("flextable")
+  # xml2 is an indirect dependency of officer/flextable, so it is always
+  # available whenever this test runs; guard anyway for clarity.
+  skip_if_not_installed("xml2")
 
   tbl <- with_gtsummary_theme(
     x = theme_gtsummary_roche(),
@@ -146,7 +149,8 @@ test_that("theme draws no internal horizontal line between spanner and column la
       t2 <- gtsummary::trial |> gtsummary::tbl_summary(by = trt, include = grade)
       gtsummary::tbl_merge(
         list(t1, t2),
-        tab_spanner = c("**Group A**", "**Group B**")
+        tab_spanner = c("**Group A**", "**Group B**"),
+        quiet = TRUE
       ) |>
         gtsummary::as_flex_table()
     }
@@ -156,15 +160,24 @@ test_that("theme draws no internal horizontal line between spanner and column la
   flextable::save_as_docx(tbl, path = f)
   d <- withr::local_tempdir()
   utils::unzip(f, exdir = d)
-  xml <- paste(readLines(file.path(d, "word", "document.xml"), warn = FALSE), collapse = "")
-  rows <- regmatches(xml, gregexpr("<w:tr\\b.*?</w:tr>", xml))[[1]]
 
-  spanner <- rows[grepl("Group A", rows)][1]
-  labels <- rows[grepl("Characteristic", rows)][1]
+  doc <- xml2::read_xml(file.path(d, "word", "document.xml"))
+  ns <- xml2::xml_ns(doc)
+  rows <- xml2::xml_find_all(doc, ".//w:tr", ns)
 
+  # Locate the spanner row and the column-label row by their text content.
+  row_text <- vapply(rows, xml2::xml_text, character(1))
+  spanner <- rows[[which(grepl("Group A", row_text))[1]]]
+  labels <- rows[[which(grepl("Characteristic", row_text))[1]]]
+
+  # Border style of the first cell on a given side, via XPath.
   border_val <- function(row, side) {
-    m <- regmatches(row, regexpr(sprintf('<w:%s w:val="[a-z]+"', side), row))
-    if (length(m)) sub('.*w:val="([a-z]+)".*', "\\1", m) else NA_character_
+    node <- xml2::xml_find_first(
+      row,
+      sprintf(".//w:tc[1]//w:tcBorders/w:%s", side),
+      ns
+    )
+    if (inherits(node, "xml_missing")) NA_character_ else xml2::xml_attr(node, "val")
   }
 
   # No line between the spanner row and the column-label row.

--- a/tests/testthat/test-theme_gtsummary_roche.R
+++ b/tests/testthat/test-theme_gtsummary_roche.R
@@ -119,8 +119,16 @@ test_that("theme pre-conversion modifies header not to be bold and border only 0
   # check no bold syntax in header
   expect_true(all(!grepl(tbl$header$dataset[1, -1], pattern = "\\*")))
 
-  # check border width is 0.5
-  expect_true(all(tbl$header$styles$cells$border.width.bottom$data == 0.5))
+  # Column labels are framed with an outer border only (width 0.5), so the
+  # outer edges carry the border while inner edges between header rows are 0.
+  n_hdr <- nrow(tbl$header$dataset)
+  bottom <- tbl$header$styles$cells$border.width.bottom$data
+  top <- tbl$header$styles$cells$border.width.top$data
+  expect_true(all(top[1, ] == 0.5)) # top of the block
+  expect_true(all(bottom[n_hdr, ] == 0.5)) # bottom of the block
+  if (n_hdr > 1) {
+    expect_true(all(bottom[-n_hdr, ] == 0)) # no internal horizontal borders
+  }
 })
 
 test_that("theme pre-conversion protects stat columns with non-breaking spaces", {

--- a/tests/testthat/test-theme_gtsummary_roche.R
+++ b/tests/testthat/test-theme_gtsummary_roche.R
@@ -166,7 +166,7 @@ test_that("theme draws no internal horizontal line between spanner and column la
   rows <- xml2::xml_find_all(doc, ".//w:tr", ns)
 
   # Locate the spanner row and the column-label row by their text content.
-  row_text <- vapply(rows, xml2::xml_text, character(1))
+  row_text <- xml2::xml_text(rows)
   spanner <- rows[[which(grepl("Group A", row_text))[1]]]
   labels <- rows[[which(grepl("Characteristic", row_text))[1]]]
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `theme_gtsummary_roche()` now frames the flextable column labels with an outer border only, removing the internal borders between header rows and the inconsistent missing right border. (#272)

`border_inner_h(part = "header")` clears the rules between header rows, then `border_outer(part = "header")` draws a single box around the column-label block. The inner border uses `officer::fp_border(width = 0, style = "none")` so docx does not render a line between a spanning header and the column labels (a width-0 *solid* border is still written as a visible line). The theme command snapshot is regenerated accordingly.

**Reference GitHub issue associated with pull request.**
closes #272