### PR TITLE
feat: add position parameter to gg_add_stats for error bar adjustments

### DIFF
--- a/R/gg_lineplot.R
+++ b/R/gg_lineplot.R
@@ -183,7 +183,7 @@ gg_lineplot <- function(data,
   # 4. Add Variability Layer conditionally to avoid drawing degenerate lines
   if (variability != "none") {
     p <- p |>
-      gg_add_stats(stat, variability, conf_level)
+      gg_add_stats(stat, variability, conf_level, position = pd)
   }
 
   # 5. Theming

--- a/R/gg_utils.R
+++ b/R/gg_utils.R
@@ -535,6 +535,10 @@ gg_varname_extraction <- function(mapping_quo) {
 #'   Measure of variability (`"sd"`, `"se"`, `"ci"`, `"iqr"`, or `"none"`).
 #' @param conf_level (`numeric`)\cr
 #'   Confidence level for `"ci"` (default `0.95`).
+#' @param position (`Position` or `character`)\cr
+#'   Position adjustment, either a string (e.g., `"dodge"`) or a
+#'   formal ggplot2 object (e.g., `ggplot2::position_dodge(width = 0.4)`).
+#'   Defaults to `ggplot2::position_identity()`.
 #'
 #' @return A modified `ggplot2` object with an added error bar layer.
 #'
@@ -556,7 +560,8 @@ gg_varname_extraction <- function(mapping_quo) {
 gg_add_stats <- function(gg_plt,
                          stat = c("mean", "median"),
                          variability = c("sd", "se", "ci", "iqr", "none"),
-                         conf_level = 0.95) {
+                         conf_level = 0.95,
+                         position = ggplot2::position_identity()) {
   stat <- match.arg(stat)
   variability <- match.arg(variability)
 
@@ -571,6 +576,7 @@ gg_add_stats <- function(gg_plt,
     ),
     geom = "errorbar",
     width = 0.45,
-    na.rm = TRUE
+    na.rm = TRUE,
+    position = position
   )
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -15,6 +15,7 @@ ORCID
 PY
 Pharmacokinetic
 Pharmacokinetics
+Revilla
 RMP
 RMPT
 RStudio

--- a/man/gg_add_stats.Rd
+++ b/man/gg_add_stats.Rd
@@ -8,7 +8,8 @@ gg_add_stats(
   gg_plt,
   stat = c("mean", "median"),
   variability = c("sd", "se", "ci", "iqr", "none"),
-  conf_level = 0.95
+  conf_level = 0.95,
+  position = ggplot2::position_identity()
 )
 }
 \arguments{
@@ -23,6 +24,11 @@ Measure of variability (\code{"sd"}, \code{"se"}, \code{"ci"}, \code{"iqr"}, or 
 
 \item{conf_level}{(\code{numeric})\cr
 Confidence level for \code{"ci"} (default \code{0.95}).}
+
+\item{position}{(\code{Position} or \code{character})\cr
+Position adjustment, either a string (e.g., \code{"dodge"}) or a
+formal ggplot2 object (e.g., \code{ggplot2::position_dodge(width = 0.4)}).
+Defaults to \code{ggplot2::position_identity()}.}
 }
 \value{
 A modified \code{ggplot2} object with an added error bar layer.


### PR DESCRIPTION
**What changes are proposed in this pull request?**
## Bug Fixes

* Fixed a bug in `gg_lineplot()` where error bars remained fixed to the center (`position_identity()`) while points and lines were correctly shifted via position adjustments. The internal `gg_add_stats()` function now accepts a `position` argument to properly pass position adjustments downstream (closes #275, @martincadek).


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
