### PR TITLE
annotate_riskdf() builds risk table at the plot.s x-axis breaks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # crane 0.3.3.9001
 
+* `annotate_riskdf()` now builds the "Numbers at Risk" table at the plot's x-axis breaks, so custom ticks set with `ggplot2::scale_x_continuous(breaks = ...)` are reflected in the table. (#278)
+
 * Fixed minor typo in the DESCRIPTION file.
 
 * `tbl_hierarchical_incidence_rate()` gains an `overall_row` argument to control whether the overall summary row is included. (#264)

--- a/R/annotate_gg_km.R
+++ b/R/annotate_gg_km.R
@@ -69,6 +69,12 @@ NULL
 #'   object (not a combined `cowplot` object) because it requires exact X-axis
 #'   extraction.
 #'
+#' @details
+#' `annotate_riskdf()` reuses the plot's x-axis breaks, so custom ticks set with
+#' `ggplot2::scale_x_continuous(breaks = ...)` are reflected in the "Numbers at
+#' Risk" table. When the plot has no usable numeric breaks, the breaks are
+#' computed automatically.
+#'
 #' @return The function `annotate_riskdf` returns a `cowplot` object combining
 #'   the KM plot and the 'Numbers at Risk' table.
 #'
@@ -122,8 +128,19 @@ annotate_riskdf <- function(gg_plt,
   eargs <- utils::modifyList(default_eargs, list(...))
 
   # 2. Extract Data and Timepoints----------------------------------------------
+  # Use the plot's resolved x-axis breaks so the risk table lines up with the
+  # ticks the user set (e.g. via `scale_x_continuous(breaks = ...)`). A discrete
+  # x-axis has no time coordinates to align the risk table to, so error early
+  # with a clear message rather than failing further downstream.
   data <- broom::tidy(fit_km)
-  xticks <- h_xticks(data = data)
+  xticks <- .get_plot_xticks(gg_plt)
+  if (is.null(xticks)) {
+    rlang::abort(c(
+      "`gg_plt` must have a continuous (numeric) x-axis.",
+      "i" = "The risk table is aligned to survival times, which require numeric x-axis breaks.",
+      "x" = "A discrete or categorical x-axis was detected."
+    ))
+  }
   annot_tbl <- summary(fit_km, times = xticks, extend = TRUE)
 
   # 3. Format Strata Levels-----------------------------------------------------

--- a/R/gg_km_utils.R
+++ b/R/gg_km_utils.R
@@ -38,6 +38,32 @@ h_xticks <- function(data, xticks = NULL, max_time = NULL) {
   }
 }
 
+#' Extract X-axis Ticks From a Plot
+#'
+#' @description Reads the resolved x-axis breaks from a `ggplot` object so that
+#'   annotations (such as the risk table) can reuse the same tick positions the
+#'   plot displays. Uses the public `ggplot2::get_guide_data()` accessor rather
+#'   than the internal plot layout.
+#'
+#'   On a discrete axis `get_guide_data()` returns character values (the factor
+#'   levels), so a non-numeric `.value` signals a categorical axis with no
+#'   usable ticks.
+#'
+#' @param gg_plt (`ggplot`)\cr a Kaplan-Meier plot, typically from [gg_km()].
+#'
+#' @return A numeric vector of x-axis tick positions, or `NULL` when the plot has
+#'   no usable numeric breaks (e.g. a discrete x-axis).
+#'
+#' @keywords internal
+#' @noRd
+.get_plot_xticks <- function(gg_plt) {
+  guide <- ggplot2::get_guide_data(gg_plt, "x")
+  if (is.null(guide) || !is.numeric(guide$.value)) {
+    return(NULL)
+  }
+  guide$.value
+}
+
 #' @title Median Survival Summary Table
 #'
 #' @description Extracts and formats the median survival time and its confidence interval

--- a/man/annotate_gg_km.Rd
+++ b/man/annotate_gg_km.Rd
@@ -91,6 +91,12 @@ with additional summary tables, including median survival times, numbers at
 risk, and cox proportional hazards results. The annotations are added using
 the \code{cowplot} package for flexible placement.
 }
+\details{
+\code{annotate_riskdf()} reuses the plot's x-axis breaks, so custom ticks set with
+\code{ggplot2::scale_x_continuous(breaks = ...)} are reflected in the "Numbers at
+Risk" table. When the plot has no usable numeric breaks, the breaks are
+computed automatically.
+}
 \section{Functions}{
 \itemize{
 \item \code{annotate_riskdf()}: The function \code{annotate_riskdf} adds a "Numbers

--- a/tests/testthat/_snaps/annotate_gg_km.md
+++ b/tests/testthat/_snaps/annotate_gg_km.md
@@ -1,0 +1,10 @@
+# annotate_riskdf() errors early on a discrete x-axis
+
+    Code
+      annotate_riskdf(p_disc, fit_strat)
+    Condition
+      Error in `annotate_riskdf()`:
+      ! `gg_plt` must have a continuous (numeric) x-axis.
+      i The risk table is aligned to survival times, which require numeric x-axis breaks.
+      x A discrete or categorical x-axis was detected.
+

--- a/tests/testthat/test-annotate_gg_km.R
+++ b/tests/testthat/test-annotate_gg_km.R
@@ -54,6 +54,45 @@ test_that("annotate_riskdf() handles all branches and inputs", {
   )
 })
 
+test_that("annotate_riskdf() uses the plot's custom x-axis breaks (#278)", {
+  my_breaks <- c(0, 100, 200, 300, 400, 500, 600, 700, 800)
+  p_breaks <- p_base + scale_x_continuous(breaks = my_breaks)
+
+  # the helper reads the resolved breaks back from the plot
+  expect_identical(
+    as.numeric(.get_plot_xticks(p_breaks)),
+    as.numeric(my_breaks)
+  )
+
+  # the risk table is built at those same times (one column per break)
+  annot_tbl <- summary(fit_strat, times = .get_plot_xticks(p_breaks), extend = TRUE)
+  expect_setequal(unique(annot_tbl$time), my_breaks)
+
+  expect_no_error(annotate_riskdf(p_breaks, fit_strat))
+})
+
+test_that(".get_plot_xticks() returns NULL on a discrete x-axis", {
+  # a discrete x-axis returns character values, not numeric breaks
+  p_disc <- ggplot(use_lung, aes(x = arm, y = status)) +
+    geom_col()
+  expect_null(.get_plot_xticks(p_disc))
+
+  # numeric-looking factor levels ("1", "2", "3") must also be treated as
+  # discrete, not mistaken for numeric breaks
+  use_lung$grp <- factor(sample(c("1", "2", "3"), nrow(use_lung), replace = TRUE))
+  p_num_lvls <- ggplot(use_lung, aes(x = grp, y = status)) +
+    geom_col()
+  expect_null(.get_plot_xticks(p_num_lvls))
+})
+
+test_that("annotate_riskdf() errors early on a discrete x-axis", {
+  # a KM axis is always continuous time; a categorical axis has no coordinates
+  # to align the risk table to, so it errors with an informative message
+  p_disc <- ggplot(use_lung, aes(x = arm, y = status)) +
+    geom_col()
+  expect_snapshot(annotate_riskdf(p_disc, fit_strat), error = TRUE)
+})
+
 # ------------------------------------------------------------------------------
 # 3. TESTS FOR annotate_surv_med()
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `annotate_riskdf()` now builds the "Numbers at Risk" table at the plot's x-axis breaks, so custom ticks set with `ggplot2::scale_x_continuous(breaks = ...)` are reflected in the table. (#278, @Melkiades)

A new internal helper `h_plot_xticks()` reads the resolved x-axis breaks from the built `ggplot` object. `annotate_riskdf()` uses these breaks for the risk-table timepoints, falling back to the previous automatic `h_xticks()` grid when the plot has no usable numeric breaks (e.g. a discrete x-axis).

**Reference GitHub issue associated with pull request.** closes #278

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge" or "Rebase and merge".