### PR TITLE
Center tbl_null_report() message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # crane 0.3.3.9012
 
+* `tbl_null_report()` now centers its message, so with no body content it reads as a "no data" panel spanning the table instead of text hugging the left edge. (#305)
+
 * Added `modify_split_caption()` to subtitle each page of a split `{gtsummary}` table (e.g. from `tbl_listing()`, `tbl_baseline_chg()`, or `tbl_shift()`) from its split level via a glue `pattern` (default `"Parameter: {spl_level}"`) and hide the now-redundant split column. (#282)
 
 * `annotate_lineplot_df()` and `annotate_pkc_df()` gain a `font_size` argument to control the summary table font size, matching `annotate_riskdf()`. The `text_size` argument of `annotate_pkc_df()` is soft-deprecated in favor of `font_size`. (#295)

--- a/R/tbl_null_report.R
+++ b/R/tbl_null_report.R
@@ -17,8 +17,12 @@ tbl_null_report <- function(label = "No observations met the reporting criteria 
   check_string(label)
 
   # Create empty gtsummary object ----------------------------------------------
+  # Center the label: with no body content the message spans the whole table, so
+  # centering reads as an intentional "no data" panel rather than text hugging
+  # the left edge.
   x <- gtsummary::as_gtsummary(data.frame(label = character())) |>
-    gtsummary::modify_header(label = label)
+    gtsummary::modify_header(label = label) |>
+    gtsummary::modify_column_alignment(columns = label, align = "center")
 
   # add class and attributes ---------------------------------------------------
   x <- structure(

--- a/tests/testthat/test-tbl_null_report.R
+++ b/tests/testthat/test-tbl_null_report.R
@@ -9,6 +9,12 @@ test_that("tbl_null_report() works correctly", {
     "No observations met the reporting criteria for this output."
   )
 
+  # message is centered so it reads as a "no data" panel spanning the table
+  expect_identical(
+    tbl_null_report()$table_styling$header$align,
+    "center"
+  )
+
   expect_error(
     tbl_null_report(label = 1)
   )


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `tbl_null_report()` now centers its message, so with no body content it reads as a "no data" panel spanning the table instead of hugging the left edge. (#305)

**Reference GitHub issue associated with pull request.** closes #305

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer
