### PR TITLE
Zero left/right cell padding in theme_gtsummary_roche()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # crane 0.3.3.9015
 
-* `theme_gtsummary_roche()` now zeros the left and right cell padding for `flextable` output (it already zeroed top and bottom), removing the ~0.19" of unused horizontal space flextable adds to every column. (#309)
-
 * `annotate_lineplot_df()` gains `"se"` and `"ci"` as `summary_stats` options, reporting the standard error and the confidence interval of the mean (at a new `conf_level` argument) in the summary table below the plot. (#307)
 
 * `gg_lineplot()` gains a `show_n` argument to append group sizes to the legend (e.g. `"Placebo (N=42)"`) and a `jitter` argument to horizontally separate overlapping groups while keeping points, lines, and error bars aligned. (#307)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # crane 0.3.3.9015
 
-* `tbl_null_report()` now centers its message, so with no body content it reads as a "no data" panel spanning the table instead of text hugging the left edge. (#305)
+* `theme_gtsummary_roche()` now zeros the left and right cell padding for `flextable` output (it already zeroed top and bottom), removing the ~0.19" of unused horizontal space flextable adds to every column. (#309)
 
 * `annotate_lineplot_df()` gains `"se"` and `"ci"` as `summary_stats` options, reporting the standard error and the confidence interval of the mean (at a new `conf_level` argument) in the summary table below the plot. (#307)
 

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -107,11 +107,6 @@ theme_gtsummary_roche <- function(font_size = NULL,
           rlang::expr(flextable::font(fontname = "Arial", part = "all")),
           rlang::expr(flextable::padding(padding.top = 0, part = "all")),
           rlang::expr(flextable::padding(padding.bottom = 0, part = "all")),
-          # zero the left/right padding too (flextable defaults to 5pt each): the
-          # extra ~0.19" per column otherwise pads every width, floating centered
-          # cells and widening empty columns.
-          rlang::expr(flextable::padding(padding.left = 0, part = "all")),
-          rlang::expr(flextable::padding(padding.right = 0, part = "all")),
           rlang::expr(flextable::line_spacing(space = 1, part = "all")),
           rlang::expr(flextable::set_table_properties(layout = "autofit"))
         )

--- a/R/theme_gtsummary_roche.R
+++ b/R/theme_gtsummary_roche.R
@@ -107,6 +107,11 @@ theme_gtsummary_roche <- function(font_size = NULL,
           rlang::expr(flextable::font(fontname = "Arial", part = "all")),
           rlang::expr(flextable::padding(padding.top = 0, part = "all")),
           rlang::expr(flextable::padding(padding.bottom = 0, part = "all")),
+          # zero the left/right padding too (flextable defaults to 5pt each): the
+          # extra ~0.19" per column otherwise pads every width, floating centered
+          # cells and widening empty columns.
+          rlang::expr(flextable::padding(padding.left = 0, part = "all")),
+          rlang::expr(flextable::padding(padding.right = 0, part = "all")),
           rlang::expr(flextable::line_spacing(space = 1, part = "all")),
           rlang::expr(flextable::set_table_properties(layout = "autofit"))
         )

--- a/tests/testthat/_snaps/theme_gtsummary_roche.md
+++ b/tests/testthat/_snaps/theme_gtsummary_roche.md
@@ -46,9 +46,16 @@
       flextable::padding(padding.bottom = 0, part = "all")
       
       $user_added3[[8]]
-      flextable::line_spacing(space = 1, part = "all")
+      flextable::padding(padding.left = 0, part = "all")
       
       $user_added3[[9]]
+      flextable::padding(padding.right = 0, part = "all")
+      
+      $user_added3[[10]]
+      flextable::line_spacing(space = 1, part = "all")
+      
+      $user_added3[[11]]
       flextable::set_table_properties(layout = "autofit")
       
       
+


### PR DESCRIPTION
The theme already zeroed top and bottom padding but left flextable's default 5pt left/right, adding ~0.19in of unused width to every column. Gridline-free listings do not need it. (#309)

**What changes are proposed in this pull request?**
* Style this entry in a way that can be copied directly into `NEWS.md`. (#<issue number>, @<username>)

Provide more detail here as needed.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
