### PR TITLE
Extend annotate_lineplot_df(): mean_se, custom labels, blank timepoints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: crane
 Title: Supplements the 'gtsummary' Package for Pharmaceutical Reporting
-Version: 0.3.3.9018
+Version: 0.3.3.9019
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-0862-2018", note = "Original creator of the package")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: crane
 Title: Supplements the 'gtsummary' Package for Pharmaceutical Reporting
-Version: 0.3.3.9017
+Version: 0.3.3.9018
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-0862-2018", note = "Original creator of the package")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# crane 0.3.3.9017
+# crane 0.3.3.9018
 
 * `tbl_null_report()` now centers its message, so with no body content it reads as a "no data" panel spanning the table instead of text hugging the left edge. (#305)
 
@@ -11,6 +11,8 @@
 * `remove_duplicate_keys()` now keeps the `tbl_split` class and attributes when applied to a split table, instead of returning a plain list. (#301)
 
 * `annotate_lineplot_df()` gains `"se"` and `"ci"` as `summary_stats` options, reporting the standard error and the confidence interval of the mean (at a new `conf_level` argument) in the summary table below the plot. (#307)
+
+* `annotate_lineplot_df()` gains a `"mean_se"` `summary_stats` option reporting the mean +/- 1 standard error interval, matching the error bars drawn by `gg_lineplot(variability = "se")`. Its row label defaults to `"Mean -/+ 1xSE"` and is configurable via the new `se_label` argument. (#307)
 
 * `gg_lineplot()` gains a `show_n` argument to append group sizes to the legend (e.g. `"Placebo (N=42)"`) and a `jitter` argument to horizontally separate overlapping groups while keeping points, lines, and error bars aligned. (#307)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 * `annotate_lineplot_df()` gains `"se"` and `"ci"` as `summary_stats` options, reporting the standard error and the confidence interval of the mean (at a new `conf_level` argument) in the summary table below the plot. (#307)
 
-* `annotate_lineplot_df()` gains a `"mean_se"` `summary_stats` option reporting the mean +/- 1 standard error interval, matching the error bars drawn by `gg_lineplot(variability = "se")`. Its row label defaults to `"Mean -/+ 1xSE"` and is configurable via the new `se_label` argument. (#307)
+* `annotate_lineplot_df()` gains a `"mean_se"` `summary_stats` option reporting the mean +/- 1 standard error interval (labelled `"Mean -/+ 1xSE"`), matching the error bars drawn by `gg_lineplot(variability = "se")`. (#307)
 
 * `annotate_lineplot_df()` gains a `labels` argument to rename statistic rows (e.g. `labels = c(mean = "LS mean")` for an MMRM plot) and a `blank_timepoints` argument to blank the continuous statistics at fixed timepoints while keeping `n` (e.g. a constant change-from-baseline visit where the mean/SD/CI are `0` by construction). (#307)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# crane 0.3.3.9018
+# crane 0.3.3.9019
 
 * `tbl_null_report()` now centers its message, so with no body content it reads as a "no data" panel spanning the table instead of text hugging the left edge. (#305)
 
@@ -13,6 +13,8 @@
 * `annotate_lineplot_df()` gains `"se"` and `"ci"` as `summary_stats` options, reporting the standard error and the confidence interval of the mean (at a new `conf_level` argument) in the summary table below the plot. (#307)
 
 * `annotate_lineplot_df()` gains a `"mean_se"` `summary_stats` option reporting the mean +/- 1 standard error interval, matching the error bars drawn by `gg_lineplot(variability = "se")`. Its row label defaults to `"Mean -/+ 1xSE"` and is configurable via the new `se_label` argument. (#307)
+
+* `annotate_lineplot_df()` gains a `labels` argument to rename statistic rows (e.g. `labels = c(mean = "LS mean")` for an MMRM plot) and a `blank_timepoints` argument to blank the continuous statistics at fixed timepoints while keeping `n` (e.g. a constant change-from-baseline visit where the mean/SD/CI are `0` by construction). (#307)
 
 * `gg_lineplot()` gains a `show_n` argument to append group sizes to the legend (e.g. `"Placebo (N=42)"`) and a `jitter` argument to horizontally separate overlapping groups while keeping points, lines, and error bars aligned. (#307)
 

--- a/R/annotate_gg.R
+++ b/R/annotate_gg.R
@@ -17,17 +17,17 @@
 #'   `"se"`, `"mean_se"`, `"ci"`, `"median"`, and `"iqr"`. Defaults to
 #'   `c("n", "mean", "sd")`. `"se"` reports the standard error on its own, while
 #'   `"mean_se"` reports the mean +/- 1 standard error interval (matching the
-#'   error bars drawn by `gg_lineplot(variability = "se")`). `"ci"` reports the
-#'   confidence interval of the mean at `conf_level`.
+#'   error bars drawn by `gg_lineplot(variability = "se")`, labelled
+#'   `"Mean -/+ 1xSE"`). `"ci"` reports the confidence interval of the mean at
+#'   `conf_level`.
 #' @param conf_level (`numeric`)\cr
 #'   Confidence level for the `"ci"` statistic. Defaults to `0.95`.
-#' @param se_label (`string`)\cr
-#'   Row label for the `"mean_se"` statistic. Defaults to `"Mean -/+ 1xSE"`.
 #' @param labels (`character` or `NULL`)\cr
 #'   Optional named vector overriding the default row labels, keyed by statistic
 #'   name (`"n"`, `"mean"`, `"sd"`, `"se"`, `"mean_se"`, `"ci"`, `"median"`,
-#'   `"iqr"`). For example, `labels = c(mean = "LS mean")` on an MMRM plot.
-#'   Defaults to `NULL` (built-in labels).
+#'   `"iqr"`). For example, `labels = c(mean = "LS mean")` on an MMRM plot, or
+#'   `labels = c(mean_se = "Mean +/- SE")` to relabel the SE interval. Defaults
+#'   to `NULL` (built-in labels).
 #' @param blank_timepoints (`character` or `NULL`)\cr
 #'   Optional vector of timepoint (x-axis level) labels at which the continuous
 #'   statistics are blanked, while the count (`"n"`) is kept. Useful for a
@@ -75,12 +75,12 @@
 #'   digits = c(0, 2, 2)
 #' )
 #'
-#' # 5. Report the mean +/- 1 SE interval with a custom label
+#' # 5. Report the mean +/- 1 SE interval, relabelled via `labels`
 #' annotate_lineplot_df(
 #'   gg_plt = p_base,
 #'   data = mock_adlb,
 #'   summary_stats = c("n", "mean", "mean_se"),
-#'   se_label = "Mean +/- SE"
+#'   labels = c(mean_se = "Mean +/- SE")
 #' )
 #'
 #' # 6. Rename a statistic and blank a constant baseline column (e.g. MMRM)
@@ -100,7 +100,6 @@ annotate_lineplot_df <- function(gg_plt,
                                  group = NULL,
                                  summary_stats = c("n", "mean", "sd"),
                                  conf_level = 0.95,
-                                 se_label = "Mean -/+ 1xSE",
                                  labels = NULL,
                                  blank_timepoints = NULL,
                                  digits = NULL,
@@ -165,7 +164,7 @@ annotate_lineplot_df <- function(gg_plt,
     "mean" = "Mean",
     "sd" = "SD",
     "se" = "SE",
-    "mean_se" = se_label,
+    "mean_se" = "Mean -/+ 1xSE",
     "ci" = ci_label,
     "median" = "Median",
     "iqr" = "IQR"

--- a/R/annotate_gg.R
+++ b/R/annotate_gg.R
@@ -14,10 +14,15 @@
 #'   automatically extracts these from the `gg_plt` mapping.
 #' @param summary_stats (`character`)\cr
 #'   Vector of statistics to include. One or more of `"n"`, `"mean"`, `"sd"`,
-#'   `"se"`, `"ci"`, `"median"`, and `"iqr"`. Defaults to `c("n", "mean", "sd")`.
-#'   `"ci"` reports the confidence interval of the mean at `conf_level`.
+#'   `"se"`, `"mean_se"`, `"ci"`, `"median"`, and `"iqr"`. Defaults to
+#'   `c("n", "mean", "sd")`. `"se"` reports the standard error on its own, while
+#'   `"mean_se"` reports the mean +/- 1 standard error interval (matching the
+#'   error bars drawn by `gg_lineplot(variability = "se")`). `"ci"` reports the
+#'   confidence interval of the mean at `conf_level`.
 #' @param conf_level (`numeric`)\cr
 #'   Confidence level for the `"ci"` statistic. Defaults to `0.95`.
+#' @param se_label (`string`)\cr
+#'   Row label for the `"mean_se"` statistic. Defaults to `"Mean -/+ 1xSE"`.
 #' @param digits (`numeric`, `list`, or `formula`)\cr
 #'   Optional specification for the number of decimal places for the summary statistics.
 #'   Can be a single integer (e.g., `2`), a vector of integers matching the statistics
@@ -60,6 +65,14 @@
 #'   digits = c(0, 2, 2)
 #' )
 #'
+#' # 5. Report the mean +/- 1 SE interval with a custom label
+#' annotate_lineplot_df(
+#'   gg_plt = p_base,
+#'   data = mock_adlb,
+#'   summary_stats = c("n", "mean", "mean_se"),
+#'   se_label = "Mean +/- SE"
+#' )
+#'
 #' @export
 annotate_lineplot_df <- function(gg_plt,
                                  data,
@@ -68,6 +81,7 @@ annotate_lineplot_df <- function(gg_plt,
                                  group = NULL,
                                  summary_stats = c("n", "mean", "sd"),
                                  conf_level = 0.95,
+                                 se_label = "Mean -/+ 1xSE",
                                  digits = NULL,
                                  font_size = 10,
                                  rel_height_plot = 0.75) {
@@ -86,6 +100,17 @@ annotate_lineplot_df <- function(gg_plt,
   }
   conf.high <- function(x) {
     .calc_stats(x, stat = "mean", variability = "ci", conf_level = conf_level)$ymax
+  }
+
+  # Mean +/- 1 SE bounds for the table, delegated to the same helper that draws
+  # the error bars in `gg_lineplot(variability = "se")` so the reported interval
+  # always matches the plot. Picked up by name in the `{se.low}` / `{se.high}`
+  # glue of the `"mean_se"` statistic below.
+  se.low <- function(x) {
+    .calc_stats(x, stat = "mean", variability = "se", conf_level = conf_level)$ymin
+  }
+  se.high <- function(x) {
+    .calc_stats(x, stat = "mean", variability = "se", conf_level = conf_level)$ymax
   }
 
   # Auto-extract variable names from the ggplot mapping if not explicitly provided
@@ -107,6 +132,7 @@ annotate_lineplot_df <- function(gg_plt,
     "mean" = "{mean}",
     "sd" = "{sd}",
     "se" = "{se}",
+    "mean_se" = "{se.low}, {se.high}",
     "ci" = "{conf.low}, {conf.high}",
     "median" = "{median}",
     "iqr" = "{p25}, {p75}"
@@ -118,6 +144,7 @@ annotate_lineplot_df <- function(gg_plt,
     "mean" = "Mean",
     "sd" = "SD",
     "se" = "SE",
+    "mean_se" = se_label,
     "ci" = ci_label,
     "median" = "Median",
     "iqr" = "IQR"

--- a/R/annotate_gg.R
+++ b/R/annotate_gg.R
@@ -23,6 +23,16 @@
 #'   Confidence level for the `"ci"` statistic. Defaults to `0.95`.
 #' @param se_label (`string`)\cr
 #'   Row label for the `"mean_se"` statistic. Defaults to `"Mean -/+ 1xSE"`.
+#' @param labels (`character` or `NULL`)\cr
+#'   Optional named vector overriding the default row labels, keyed by statistic
+#'   name (`"n"`, `"mean"`, `"sd"`, `"se"`, `"mean_se"`, `"ci"`, `"median"`,
+#'   `"iqr"`). For example, `labels = c(mean = "LS mean")` on an MMRM plot.
+#'   Defaults to `NULL` (built-in labels).
+#' @param blank_timepoints (`character` or `NULL`)\cr
+#'   Optional vector of timepoint (x-axis level) labels at which the continuous
+#'   statistics are blanked, while the count (`"n"`) is kept. Useful for a
+#'   constant change-from-baseline visit in an MMRM plot, where the mean/SD/CI
+#'   are `0` by construction and carry no information. Defaults to `NULL`.
 #' @param digits (`numeric`, `list`, or `formula`)\cr
 #'   Optional specification for the number of decimal places for the summary statistics.
 #'   Can be a single integer (e.g., `2`), a vector of integers matching the statistics
@@ -73,6 +83,15 @@
 #'   se_label = "Mean +/- SE"
 #' )
 #'
+#' # 6. Rename a statistic and blank a constant baseline column (e.g. MMRM)
+#' annotate_lineplot_df(
+#'   gg_plt = p_base,
+#'   data = mock_adlb,
+#'   summary_stats = c("n", "mean", "sd"),
+#'   labels = c(mean = "LS mean"),
+#'   blank_timepoints = "0"
+#' )
+#'
 #' @export
 annotate_lineplot_df <- function(gg_plt,
                                  data,
@@ -82,6 +101,8 @@ annotate_lineplot_df <- function(gg_plt,
                                  summary_stats = c("n", "mean", "sd"),
                                  conf_level = 0.95,
                                  se_label = "Mean -/+ 1xSE",
+                                 labels = NULL,
+                                 blank_timepoints = NULL,
                                  digits = NULL,
                                  font_size = 10,
                                  rel_height_plot = 0.75) {
@@ -150,6 +171,22 @@ annotate_lineplot_df <- function(gg_plt,
     "iqr" = "IQR"
   )
 
+  # Override any default row labels with user-supplied ones, e.g.
+  # `labels = c(mean = "LS mean")` for an MMRM plot.
+  if (!is.null(labels)) {
+    if (is.null(names(labels)) || any(names(labels) == "")) {
+      cli::cli_abort("{.arg labels} must be a named vector, e.g. {.code c(mean = \"LS mean\")}.")
+    }
+    unknown <- setdiff(names(labels), names(stat_labels))
+    if (length(unknown) > 0) {
+      cli::cli_abort(c(
+        "Unknown statistic{?s} in {.arg labels}: {.val {unknown}}.",
+        "i" = "Valid names are {.val {names(stat_labels)}}."
+      ))
+    }
+    stat_labels[names(labels)] <- labels
+  }
+
   summary_stats <- match.arg(
     summary_stats,
     choices = names(stat_syntax),
@@ -200,6 +237,25 @@ annotate_lineplot_df <- function(gg_plt,
 
   raw_labels <- as.character(formatted_df[[1]])
   is_stat <- trimws(raw_labels) %in% trimws(gts_stat_labels)
+
+  # Blank the continuous statistics at fixed timepoints (e.g. a constant-zero
+  # change-from-baseline visit in an MMRM plot), where a "0.00" mean/SD/CI is an
+  # artifact of the constant rather than a real estimate. The count ("n") is a
+  # genuine value and is kept.
+  if (!is.null(blank_timepoints)) {
+    missing_tp <- setdiff(blank_timepoints, names(formatted_df))
+    if (length(missing_tp) > 0) {
+      cli::cli_warn(c(
+        "!" = "Timepoint{?s} in {.arg blank_timepoints} not found: {.val {missing_tp}}.",
+        "i" = "Available timepoint columns are {.val {setdiff(names(formatted_df), c(names(formatted_df)[1], 'Group'))}}."
+      ))
+    }
+    n_label <- trimws(stat_labels[["n"]])
+    blank_rows <- is_stat & trimws(raw_labels) != n_label
+    for (tp in intersect(blank_timepoints, names(formatted_df))) {
+      formatted_df[blank_rows, tp] <- ""
+    }
+  }
 
   # Apply Plotmath styling (bold for headers, indent for stats)
   y_labels <- parse(text = ifelse(

--- a/man/annotate_lineplot_df.Rd
+++ b/man/annotate_lineplot_df.Rd
@@ -12,7 +12,6 @@ annotate_lineplot_df(
   group = NULL,
   summary_stats = c("n", "mean", "sd"),
   conf_level = 0.95,
-  se_label = "Mean -/+ 1xSE",
   labels = NULL,
   blank_timepoints = NULL,
   digits = NULL,
@@ -36,20 +35,19 @@ Vector of statistics to include. One or more of \code{"n"}, \code{"mean"}, \code
 \code{"se"}, \code{"mean_se"}, \code{"ci"}, \code{"median"}, and \code{"iqr"}. Defaults to
 \code{c("n", "mean", "sd")}. \code{"se"} reports the standard error on its own, while
 \code{"mean_se"} reports the mean +/- 1 standard error interval (matching the
-error bars drawn by \code{gg_lineplot(variability = "se")}). \code{"ci"} reports the
-confidence interval of the mean at \code{conf_level}.}
+error bars drawn by \code{gg_lineplot(variability = "se")}, labelled
+\code{"Mean -/+ 1xSE"}). \code{"ci"} reports the confidence interval of the mean at
+\code{conf_level}.}
 
 \item{conf_level}{(\code{numeric})\cr
 Confidence level for the \code{"ci"} statistic. Defaults to \code{0.95}.}
 
-\item{se_label}{(\code{string})\cr
-Row label for the \code{"mean_se"} statistic. Defaults to \code{"Mean -/+ 1xSE"}.}
-
 \item{labels}{(\code{character} or \code{NULL})\cr
 Optional named vector overriding the default row labels, keyed by statistic
 name (\code{"n"}, \code{"mean"}, \code{"sd"}, \code{"se"}, \code{"mean_se"}, \code{"ci"}, \code{"median"},
-\code{"iqr"}). For example, \code{labels = c(mean = "LS mean")} on an MMRM plot.
-Defaults to \code{NULL} (built-in labels).}
+\code{"iqr"}). For example, \code{labels = c(mean = "LS mean")} on an MMRM plot, or
+\code{labels = c(mean_se = "Mean +/- SE")} to relabel the SE interval. Defaults
+to \code{NULL} (built-in labels).}
 
 \item{blank_timepoints}{(\code{character} or \code{NULL})\cr
 Optional vector of timepoint (x-axis level) labels at which the continuous
@@ -105,12 +103,12 @@ annotate_lineplot_df(
   digits = c(0, 2, 2)
 )
 
-# 5. Report the mean +/- 1 SE interval with a custom label
+# 5. Report the mean +/- 1 SE interval, relabelled via `labels`
 annotate_lineplot_df(
   gg_plt = p_base,
   data = mock_adlb,
   summary_stats = c("n", "mean", "mean_se"),
-  se_label = "Mean +/- SE"
+  labels = c(mean_se = "Mean +/- SE")
 )
 
 # 6. Rename a statistic and blank a constant baseline column (e.g. MMRM)

--- a/man/annotate_lineplot_df.Rd
+++ b/man/annotate_lineplot_df.Rd
@@ -12,6 +12,7 @@ annotate_lineplot_df(
   group = NULL,
   summary_stats = c("n", "mean", "sd"),
   conf_level = 0.95,
+  se_label = "Mean -/+ 1xSE",
   digits = NULL,
   font_size = 10,
   rel_height_plot = 0.75
@@ -30,11 +31,17 @@ automatically extracts these from the \code{gg_plt} mapping.}
 
 \item{summary_stats}{(\code{character})\cr
 Vector of statistics to include. One or more of \code{"n"}, \code{"mean"}, \code{"sd"},
-\code{"se"}, \code{"ci"}, \code{"median"}, and \code{"iqr"}. Defaults to \code{c("n", "mean", "sd")}.
-\code{"ci"} reports the confidence interval of the mean at \code{conf_level}.}
+\code{"se"}, \code{"mean_se"}, \code{"ci"}, \code{"median"}, and \code{"iqr"}. Defaults to
+\code{c("n", "mean", "sd")}. \code{"se"} reports the standard error on its own, while
+\code{"mean_se"} reports the mean +/- 1 standard error interval (matching the
+error bars drawn by \code{gg_lineplot(variability = "se")}). \code{"ci"} reports the
+confidence interval of the mean at \code{conf_level}.}
 
 \item{conf_level}{(\code{numeric})\cr
 Confidence level for the \code{"ci"} statistic. Defaults to \code{0.95}.}
+
+\item{se_label}{(\code{string})\cr
+Row label for the \code{"mean_se"} statistic. Defaults to \code{"Mean -/+ 1xSE"}.}
 
 \item{digits}{(\code{numeric}, \code{list}, or \code{formula})\cr
 Optional specification for the number of decimal places for the summary statistics.
@@ -82,6 +89,14 @@ annotate_lineplot_df(
   data = mock_adlb,
   summary_stats = c("n", "median", "iqr"),
   digits = c(0, 2, 2)
+)
+
+# 5. Report the mean +/- 1 SE interval with a custom label
+annotate_lineplot_df(
+  gg_plt = p_base,
+  data = mock_adlb,
+  summary_stats = c("n", "mean", "mean_se"),
+  se_label = "Mean +/- SE"
 )
 
 }

--- a/man/annotate_lineplot_df.Rd
+++ b/man/annotate_lineplot_df.Rd
@@ -13,6 +13,8 @@ annotate_lineplot_df(
   summary_stats = c("n", "mean", "sd"),
   conf_level = 0.95,
   se_label = "Mean -/+ 1xSE",
+  labels = NULL,
+  blank_timepoints = NULL,
   digits = NULL,
   font_size = 10,
   rel_height_plot = 0.75
@@ -42,6 +44,18 @@ Confidence level for the \code{"ci"} statistic. Defaults to \code{0.95}.}
 
 \item{se_label}{(\code{string})\cr
 Row label for the \code{"mean_se"} statistic. Defaults to \code{"Mean -/+ 1xSE"}.}
+
+\item{labels}{(\code{character} or \code{NULL})\cr
+Optional named vector overriding the default row labels, keyed by statistic
+name (\code{"n"}, \code{"mean"}, \code{"sd"}, \code{"se"}, \code{"mean_se"}, \code{"ci"}, \code{"median"},
+\code{"iqr"}). For example, \code{labels = c(mean = "LS mean")} on an MMRM plot.
+Defaults to \code{NULL} (built-in labels).}
+
+\item{blank_timepoints}{(\code{character} or \code{NULL})\cr
+Optional vector of timepoint (x-axis level) labels at which the continuous
+statistics are blanked, while the count (\code{"n"}) is kept. Useful for a
+constant change-from-baseline visit in an MMRM plot, where the mean/SD/CI
+are \code{0} by construction and carry no information. Defaults to \code{NULL}.}
 
 \item{digits}{(\code{numeric}, \code{list}, or \code{formula})\cr
 Optional specification for the number of decimal places for the summary statistics.
@@ -97,6 +111,15 @@ annotate_lineplot_df(
   data = mock_adlb,
   summary_stats = c("n", "mean", "mean_se"),
   se_label = "Mean +/- SE"
+)
+
+# 6. Rename a statistic and blank a constant baseline column (e.g. MMRM)
+annotate_lineplot_df(
+  gg_plt = p_base,
+  data = mock_adlb,
+  summary_stats = c("n", "mean", "sd"),
+  labels = c(mean = "LS mean"),
+  blank_timepoints = "0"
 )
 
 }

--- a/tests/testthat/test-annotate_gg.R
+++ b/tests/testthat/test-annotate_gg.R
@@ -249,7 +249,7 @@ test_that("annotate_lineplot_df mean_se reports the mean +/- 1 SE interval", {
   expect_equal(got, expected, tolerance = 1e-2)
 })
 
-test_that("annotate_lineplot_df mean_se label is configurable via se_label", {
+test_that("annotate_lineplot_df mean_se label is configurable via labels", {
   mock_df2gg <- function(df, ...) df
 
   res_df <- testthat::with_mocked_bindings(
@@ -258,7 +258,7 @@ test_that("annotate_lineplot_df mean_se label is configurable via se_label", {
         gg_plt = p_valid,
         data = mock_adlb,
         summary_stats = c("mean", "mean_se"),
-        se_label = "Mean +/- SE"
+        labels = c(mean_se = "Mean +/- SE")
       )
     },
     df2gg_aligned = mock_df2gg

--- a/tests/testthat/test-annotate_gg.R
+++ b/tests/testthat/test-annotate_gg.R
@@ -267,6 +267,84 @@ test_that("annotate_lineplot_df mean_se label is configurable via se_label", {
   expect_true(any(grepl("Mean \\+/- SE", trimws(res_df$Group))))
 })
 
+test_that("annotate_lineplot_df renames statistics via labels", {
+  mock_df2gg <- function(df, ...) df
+
+  res_df <- testthat::with_mocked_bindings(
+    {
+      annotate_lineplot_df(
+        gg_plt = p_valid,
+        data = mock_adlb,
+        summary_stats = c("n", "mean", "sd"),
+        labels = c(mean = "LS mean")
+      )
+    },
+    df2gg_aligned = mock_df2gg
+  )
+
+  labels_seen <- trimws(res_df$Group)
+  expect_true(any(labels_seen == "LS mean"))
+  expect_false(any(labels_seen == "Mean"))
+  # Untouched labels remain
+  expect_true(any(labels_seen == "SD"))
+})
+
+test_that("annotate_lineplot_df rejects invalid labels", {
+  expect_error(
+    annotate_lineplot_df(gg_plt = p_valid, data = mock_adlb, labels = "LS mean"),
+    regexp = "must be a named vector"
+  )
+  expect_error(
+    annotate_lineplot_df(gg_plt = p_valid, data = mock_adlb, labels = c(foo = "Bar")),
+    regexp = "Unknown statistic"
+  )
+})
+
+test_that("annotate_lineplot_df blanks continuous stats at blank_timepoints", {
+  mock_df2gg <- function(df, ...) df
+
+  res_df <- testthat::with_mocked_bindings(
+    {
+      annotate_lineplot_df(
+        gg_plt = p_valid,
+        data = mock_adlb,
+        summary_stats = c("n", "mean", "sd"),
+        blank_timepoints = "0"
+      )
+    },
+    df2gg_aligned = mock_df2gg
+  )
+
+  labels_seen <- trimws(res_df$Group)
+  # The baseline column ("0") is blank for continuous stats but keeps n
+  mean_rows <- which(labels_seen == "Mean")
+  sd_rows <- which(labels_seen == "SD")
+  n_rows <- which(labels_seen == "n")
+
+  expect_true(all(res_df[["0"]][mean_rows] == ""))
+  expect_true(all(res_df[["0"]][sd_rows] == ""))
+  expect_true(all(res_df[["0"]][n_rows] != ""))
+
+  # Other timepoints are unaffected
+  expect_true(all(res_df[["4"]][mean_rows] != ""))
+})
+
+test_that("annotate_lineplot_df warns on unknown blank_timepoints", {
+  mock_df2gg <- function(df, ...) df
+
+  expect_warning(
+    testthat::with_mocked_bindings(
+      annotate_lineplot_df(
+        gg_plt = p_valid,
+        data = mock_adlb,
+        blank_timepoints = "NoSuchVisit"
+      ),
+      df2gg_aligned = mock_df2gg
+    ),
+    regexp = "not found"
+  )
+})
+
 test_that("annotate_lineplot_df forwards font_size to df2gg_aligned", {
   captured <- NULL
   mock_df2gg <- function(df, ..., text_size, label_size) {

--- a/tests/testthat/test-annotate_gg.R
+++ b/tests/testthat/test-annotate_gg.R
@@ -217,6 +217,56 @@ test_that("annotate_lineplot_df ci label follows conf_level", {
   expect_true(any(grepl("90% CI", trimws(res_df$Group))))
 })
 
+test_that("annotate_lineplot_df mean_se reports the mean +/- 1 SE interval", {
+  mock_df2gg <- function(df, ...) df
+
+  res_df <- testthat::with_mocked_bindings(
+    {
+      annotate_lineplot_df(
+        gg_plt = p_valid,
+        data = mock_adlb,
+        summary_stats = c("n", "mean", "mean_se")
+      )
+    },
+    df2gg_aligned = mock_df2gg
+  )
+
+  expect_s3_class(res_df, "data.frame")
+
+  # The mean_se row carries the default label
+  expect_true(any(grepl("Mean -/\\+ 1xSE", trimws(res_df$Group))))
+
+  # Verify Visit '0' interval equals mean +/- se for the first treatment group
+  x <- mock_adlb$AVAL[mock_adlb$AVISIT == 0 & mock_adlb$ARM == "Trt A"]
+  se <- stats::sd(x) / sqrt(length(x))
+  expected <- c(mean(x) - se, mean(x) + se)
+
+  val_se <- res_df[grepl("1xSE$", trimws(res_df$Group)), "0"][1]
+  # gtsummary separates the bounds with a non-breaking space; extract the numbers
+  nums <- regmatches(val_se, gregexpr("-?[0-9.]+", val_se))[[1]]
+  got <- as.numeric(nums)
+
+  expect_equal(got, expected, tolerance = 1e-2)
+})
+
+test_that("annotate_lineplot_df mean_se label is configurable via se_label", {
+  mock_df2gg <- function(df, ...) df
+
+  res_df <- testthat::with_mocked_bindings(
+    {
+      annotate_lineplot_df(
+        gg_plt = p_valid,
+        data = mock_adlb,
+        summary_stats = c("mean", "mean_se"),
+        se_label = "Mean +/- SE"
+      )
+    },
+    df2gg_aligned = mock_df2gg
+  )
+
+  expect_true(any(grepl("Mean \\+/- SE", trimws(res_df$Group))))
+})
+
 test_that("annotate_lineplot_df forwards font_size to df2gg_aligned", {
   captured <- NULL
   mock_df2gg <- function(df, ..., text_size, label_size) {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `annotate_lineplot_df()` gains a `"mean_se"` `summary_stats` option reporting the mean +/- 1 standard error interval, matching the error bars drawn by `gg_lineplot(variability = "se")`. Its row label defaults to `"Mean -/+ 1xSE"` and is configurable via the new `se_label` argument. (#307)
* `annotate_lineplot_df()` gains a `labels` argument to rename statistic rows (e.g. `labels = c(mean = "LS mean")` for an MMRM plot) and a `blank_timepoints` argument to blank the continuous statistics at fixed timepoints while keeping `n` (e.g. a constant change-from-baseline visit where the mean/SD/CI are `0` by construction). (#307)

These are follow-ups from annotating MMRM change-from-baseline plots:
- `"mean_se"` mirrors the plot's SE error bars in the table (bounds delegate to the same `.calc_stats()` helper the plot uses, so they can never disagree).
- `labels` lets an MMRM plot report "LS mean" instead of the generic "Mean".
- `blank_timepoints` removes the meaningless `0.00` mean/SD/CI at the constant baseline visit while keeping the sample size.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_

Part of #307.

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
